### PR TITLE
Rename jj_project to git_project for proper project identification

### DIFF
--- a/.claude/skills/daily-standup/SKILL.md
+++ b/.claude/skills/daily-standup/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: daily-standup
+description: Use when posting a daily standup, status update, or YTH report to Slack using time-tracker activity data
+---
+
+# Daily Standup
+
+Generate and post a daily standup to Slack using time-tracker activity data.
+
+## Arguments
+
+- `channel`: Required. Slack channel name (e.g., `#ra-lab-notes-sami`)
+- `date`: Optional. Day to report on (default: yesterday). Use natural language like "yesterday", "Feb 2", or ISO 8601.
+
+Example: `/daily-standup #ra-lab-notes-sami yesterday`
+
+## Workflow
+
+```dot
+digraph standup {
+  rankdir=TB;
+  node [shape=box];
+
+  start [label="1. Parse date\n(convert to ISO 8601 UTC)" shape=ellipse];
+  gather [label="2. Gather context\ntt context --events --agents"];
+  analyze [label="3. Analyze sessions\nGroup by project"];
+  draft [label="4. Draft update\n(context for readers)"];
+  confirm [label="5. Confirm channel\nwith user"];
+  post [label="6. Post to Slack"];
+
+  start -> gather -> analyze -> draft -> confirm -> post;
+}
+```
+
+## Phase 1: Parse Date
+
+Convert user's date to ISO 8601 UTC range.
+
+**Critical**: `tt context` only accepts ISO 8601 format or relative strings.
+
+| User input | Start (UTC) | End (UTC) |
+|------------|-------------|-----------|
+| "yesterday" | Yesterday 08:00 UTC | Today 08:00 UTC |
+| "Feb 2" | 2026-02-02T08:00:00Z | 2026-02-03T08:00:00Z |
+| "today" | Today 08:00 UTC | Now |
+
+Use `date` command to compute if needed:
+```bash
+# Yesterday's range (Pacific = UTC-8)
+START=$(date -u -d "yesterday 00:00 PST" +%Y-%m-%dT%H:%M:%SZ)
+END=$(date -u -d "today 00:00 PST" +%Y-%m-%dT%H:%M:%SZ)
+```
+
+## Phase 2: Gather Context
+
+```bash
+tt context --events --agents --start "$START" --end "$END"
+```
+
+This outputs JSON with:
+- `agents[]`: Claude sessions with `project_name`, `summary`, `tool_call_count`, `start_time`, `end_time`
+- `events[]`: Raw activity signals (used for direct time calculation)
+
+## Phase 3: Analyze Sessions
+
+Group agents by `project_name`. For each project:
+
+1. **Count sessions** with substantive work (`tool_call_count > 10` or non-trivial summary)
+2. **Extract work items** from `summary` field — if null, check `starting_prompt` for context
+3. **Calculate delegated time**: Sum of `(end_time - start_time)` for sessions with both times; estimate for null end_times based on tool_call_count (~1 min per 10 tool calls)
+4. **Note direct time**: Rough proxy using session count × 15-30 min per substantive session
+
+**Filtering heuristics:**
+- Skip sessions with `tool_call_count < 10` AND no meaningful summary
+- Skip `/clear`, `/ide`, `/context` sessions (administrative, no real work)
+- Include sessions where `starting_prompt` shows real user intent even if summary is null
+
+**Project naming caveat:** The time-tracker extracts `project_name` from the working directory. For nested repos (e.g., `/eval-pipeline/pivot`), only the deepest directory is captured (`pivot`). Check `cwd` in events if work seems missing from a parent project.
+
+## Phase 4: Draft Update
+
+**Format: YTH (Yesterday, Today, Hopes/Blockers)**
+
+Write for readers who have no context about your projects:
+
+```markdown
+## Standup - {Day of Week} {Date}
+
+### Yesterday ({Date})
+
+- **{Project}** — {time estimate}
+  - {What was accomplished in 1 sentence, understandable to outsiders}
+  - {Another accomplishment if significant}
+
+- **{Project}** — {time estimate}
+  - {Accomplishment}
+
+**Totals:** ~{X} hrs direct | ~{Y} hrs delegated
+
+{Optional: Brief note about slowdowns or context}
+
+### Today
+
+- {Plan item 1}
+- {Plan item 2}
+
+### Blockers
+
+- {Blocker, or "None" if clear}
+```
+
+**Writing guidelines:**
+- Project names should be recognizable (use repo names or common abbreviations)
+- Accomplishments should be specific enough that someone unfamiliar can understand impact
+- Avoid jargon like "refactoring" without saying what/why
+- Time estimates are approximate—don't overthink precision
+- Delegated time can be very high with parallel agents (10+ hours is normal for heavy days)
+
+## Phase 5: Ask for "Today" Plans
+
+The time-tracker data only shows past activity. Ask the user:
+- "What are your plans for today?"
+- "Any blockers?"
+
+If user provided plans in the invocation, use those. Otherwise, infer reasonable continuations from yesterday's work (e.g., "continue X" or "open PR for Y").
+
+## Phase 6: Confirm Before Posting
+
+Show the drafted message and confirm:
+- Target channel is correct
+- Content looks accurate
+
+Use AskUserQuestion if channel wasn't provided or to confirm before posting.
+
+## Phase 7: Post to Slack
+
+Use `mcp__slack__conversations_add_message`:
+- `channel_id`: Use `#channel-name` format
+- `content_type`: `text/markdown`
+- `payload`: The drafted message
+
+**Slack markdown note:** Slack's markdown support is limited. Nested bullets may appear flattened in some clients. Format for readability anyway—the structure helps even if rendering is imperfect.
+
+```markdown
+- **Project** — time
+  - Sub-item (2 spaces before -)
+  - Another sub-item
+```
+
+If posting fails:
+1. Check channel name/ID
+2. Try without special formatting
+3. Report error to user
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Date format error | Use ISO 8601: `2026-02-02T08:00:00Z` or relative like "1 day ago" |
+| Wrong year | Check current date first—don't assume from context |
+| Updates too terse | Include context for outsiders ("what" and "why") |
+| Missing sessions | Check `starting_prompt` when `summary` is null |
+| Null end_time | Estimate from tool_call_count (~1 min per 10 calls) |
+| No "Today" plans | Ask user—can't infer future plans from past data |
+
+## Example Output
+
+```markdown
+## Standup - Mon Feb 3, 2026
+
+### Yesterday (Feb 2)
+
+- **Legion** — 2h direct | 10h delegated
+  - Completed daemon worker monitoring implementation (workers now report health status)
+  - Set up tmux-based session architecture for parallel agent execution
+
+- **eval-pipeline** — 15min direct | 30min delegated
+  - Started validation work for new test harness (in progress)
+
+- **time-tracker** — 1h direct | 5h delegated
+  - Fixed report time calculation to use period events, not cumulative totals
+
+**Totals:** ~3h direct | ~15h delegated (parallel agent sessions)
+
+### Today
+
+- Finish eval-pipeline validation and open PR
+- Debug Legion worker communication issues
+
+### Blockers
+
+- None currently
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"

--- a/crates/tt-cli/src/commands/import.rs
+++ b/crates/tt-cli/src/commands/import.rs
@@ -48,7 +48,14 @@ pub fn import_from_reader<R: Read>(db: &Database, reader: R) -> Result<ImportRes
         }
 
         match serde_json::from_str::<StoredEvent>(&line) {
-            Ok(event) => {
+            Ok(mut event) => {
+                // Clear stream_id and assignment_source during import - events will be
+                // re-assigned to streams after import via the inference algorithm.
+                // The original stream_id would violate foreign key constraints anyway
+                // since the stream doesn't exist in this database.
+                event.stream_id = None;
+                event.assignment_source = None;
+
                 result.total_read += 1;
                 batch.push(event);
 

--- a/crates/tt-cli/src/commands/recompute.rs
+++ b/crates/tt-cli/src/commands/recompute.rs
@@ -53,16 +53,15 @@ pub fn run(db: &Database, force: bool) -> Result<()> {
     // Filter results to only streams we want to update
     let times_to_update: Vec<_> = if force {
         // Update all streams that have time computed
-        result.stream_times.clone()
+        result.stream_times
     } else {
         // Only update streams that were marked for recomputation
         let stream_ids_to_update: std::collections::HashSet<_> =
             streams.iter().map(|s| s.id.as_str()).collect();
         result
             .stream_times
-            .iter()
+            .into_iter()
             .filter(|t| stream_ids_to_update.contains(t.stream_id.as_str()))
-            .cloned()
             .collect()
     };
 
@@ -113,11 +112,19 @@ mod tests {
             event_type: "tmux_pane_focus".to_string(),
             source: "remote.tmux".to_string(),
             schema_version: 1,
-            data: json!({"pane_id": "%1", "cwd": cwd}),
+            pane_id: Some("%1".to_string()),
+            tmux_session: None,
+            window_index: None,
+            git_project: None,
+            git_workspace: None,
+            status: None,
+            idle_duration_ms: None,
+            action: None,
             cwd: Some(cwd.to_string()),
             session_id: None,
             stream_id: Some(stream_id.to_string()),
             assignment_source: Some("inferred".to_string()),
+            data: json!({}),
         }
     }
 
@@ -134,11 +141,19 @@ mod tests {
             event_type: "agent_session".to_string(),
             source: "remote.agent".to_string(),
             schema_version: 1,
-            data: json!({"action": action, "agent": "claude-code"}),
+            pane_id: None,
+            tmux_session: None,
+            window_index: None,
+            git_project: None,
+            git_workspace: None,
+            status: None,
+            idle_duration_ms: None,
+            action: Some(action.to_string()),
             cwd: Some("/project".to_string()),
             session_id: Some(session_id.to_string()),
             stream_id: Some(stream_id.to_string()),
             assignment_source: Some("inferred".to_string()),
+            data: json!({}),
         }
     }
 
@@ -154,11 +169,19 @@ mod tests {
             event_type: "agent_tool_use".to_string(),
             source: "remote.agent".to_string(),
             schema_version: 1,
-            data: json!({"tool": "Edit"}),
+            pane_id: None,
+            tmux_session: None,
+            window_index: None,
+            git_project: None,
+            git_workspace: None,
+            status: None,
+            idle_duration_ms: None,
+            action: None,
             cwd: Some("/project".to_string()),
             session_id: Some(session_id.to_string()),
             stream_id: Some(stream_id.to_string()),
             assignment_source: Some("inferred".to_string()),
+            data: json!({}),
         }
     }
 

--- a/crates/tt-cli/src/commands/report.rs
+++ b/crates/tt-cli/src/commands/report.rs
@@ -204,10 +204,8 @@ pub fn generate_report_data(
 
     // Get stream metadata (names) for display
     let all_streams = db.get_streams().context("failed to get streams")?;
-    let stream_names: HashMap<String, Option<String>> = all_streams
-        .into_iter()
-        .map(|s| (s.id, s.name))
-        .collect();
+    let stream_names: HashMap<String, Option<String>> =
+        all_streams.into_iter().map(|s| (s.id, s.name)).collect();
 
     // Convert allocation results to report format, excluding zero-time streams
     let streams: Vec<ReportStreamTime> = result
@@ -627,7 +625,12 @@ mod tests {
 
     // ========== Integration Tests (Snapshot) ==========
 
-    fn make_test_stream(id: &str, name: &str, direct_ms: i64, delegated_ms: i64) -> ReportStreamTime {
+    fn make_test_stream(
+        id: &str,
+        name: &str,
+        direct_ms: i64,
+        delegated_ms: i64,
+    ) -> ReportStreamTime {
         ReportStreamTime {
             id: id.to_string(),
             name: Some(name.to_string()),

--- a/crates/tt-cli/src/commands/status.rs
+++ b/crates/tt-cli/src/commands/status.rs
@@ -57,11 +57,19 @@ mod tests {
             event_type: "test_event".to_string(),
             source: source.to_string(),
             schema_version: 1,
-            data: json!({}),
+            pane_id: None,
+            tmux_session: None,
+            window_index: None,
+            git_project: None,
+            git_workspace: None,
+            status: None,
+            idle_duration_ms: None,
+            action: None,
             cwd: None,
             session_id: None,
             stream_id: None,
             assignment_source: None,
+            data: json!({}),
         }
     }
 

--- a/crates/tt-cli/src/commands/suggest.rs
+++ b/crates/tt-cli/src/commands/suggest.rs
@@ -61,11 +61,9 @@ pub async fn run(db: &Database, stream_id: &str, json: bool) -> Result<()> {
 
     // Try metadata-based suggestion first
     let mut suggestion = suggest_from_metadata(&cwds);
-    let mut source = if suggestion.is_some() {
-        SuggestionSource::Metadata
-    } else {
-        SuggestionSource::None
-    };
+    let mut source = suggestion
+        .as_ref()
+        .map_or(SuggestionSource::None, |_| SuggestionSource::Metadata);
 
     // If metadata is ambiguous, try LLM
     if suggestion.is_none() && is_metadata_ambiguous(&cwds) {
@@ -239,11 +237,19 @@ mod tests {
             event_type: "tmux_pane_focus".to_string(),
             source: "remote.tmux".to_string(),
             schema_version: 1,
-            data: json!({}),
+            pane_id: None,
+            tmux_session: None,
+            window_index: None,
+            git_project: None,
+            git_workspace: None,
+            status: None,
+            idle_duration_ms: None,
+            action: None,
             cwd: Some(cwd.to_string()),
             session_id: None,
             stream_id: Some(stream_id.to_string()),
             assignment_source: Some("inferred".to_string()),
+            data: json!({}),
         }
     }
 

--- a/crates/tt-core/src/allocation.rs
+++ b/crates/tt-core/src/allocation.rs
@@ -75,6 +75,9 @@ pub trait AllocatableEvent {
     /// Returns the agent session ID if applicable.
     fn session_id(&self) -> Option<&str>;
 
+    /// Returns the action for `agent_session` events (e.g., "started", "ended").
+    fn action(&self) -> Option<&str>;
+
     /// Returns the event's data payload.
     fn data(&self) -> &serde_json::Value;
 }
@@ -343,7 +346,7 @@ pub fn allocate_time<E: AllocatableEvent>(
             }
 
             "agent_session" => {
-                let action = data.get("action").and_then(|v| v.as_str()).unwrap_or("");
+                let action = event.action().unwrap_or("");
                 let session_id = event.session_id().unwrap_or("");
 
                 match action {
@@ -609,6 +612,7 @@ mod tests {
         event_type: String,
         stream_id: Option<String>,
         session_id: Option<String>,
+        action: Option<String>,
         data: serde_json::Value,
     }
 
@@ -619,6 +623,7 @@ mod tests {
                 event_type: "tmux_pane_focus".to_string(),
                 stream_id: Some(stream_id.to_string()),
                 session_id: None,
+                action: None,
                 data: json!({"pane_id": "%1", "cwd": "/test"}),
             }
         }
@@ -629,6 +634,7 @@ mod tests {
                 event_type: "afk_change".to_string(),
                 stream_id: None,
                 session_id: None,
+                action: None,
                 data: json!({"status": status}),
             }
         }
@@ -639,6 +645,7 @@ mod tests {
                 event_type: "tmux_scroll".to_string(),
                 stream_id: Some(stream_id.to_string()),
                 session_id: None,
+                action: None,
                 data: json!({"direction": "up"}),
             }
         }
@@ -654,7 +661,8 @@ mod tests {
                 event_type: "agent_session".to_string(),
                 stream_id: stream_id.map(String::from),
                 session_id: Some(session_id.to_string()),
-                data: json!({"action": action, "agent": "claude-code"}),
+                action: Some(action.to_string()),
+                data: json!({"agent": "claude-code"}),
             }
         }
 
@@ -664,6 +672,7 @@ mod tests {
                 event_type: "agent_tool_use".to_string(),
                 stream_id: Some(stream_id.to_string()),
                 session_id: Some(session_id.to_string()),
+                action: None,
                 data: json!({"tool": "Edit"}),
             }
         }
@@ -674,6 +683,7 @@ mod tests {
                 event_type: "user_message".to_string(),
                 stream_id: Some(stream_id.to_string()),
                 session_id: Some(session_id.to_string()),
+                action: None,
                 data: json!({"length": 100}),
             }
         }
@@ -684,6 +694,7 @@ mod tests {
                 event_type: "window_focus".to_string(),
                 stream_id: stream_id.map(String::from),
                 session_id: None,
+                action: None,
                 data: json!({"app": app, "title": "test window"}),
             }
         }
@@ -694,6 +705,7 @@ mod tests {
                 event_type: "browser_tab".to_string(),
                 stream_id: Some(stream_id.to_string()),
                 session_id: None,
+                action: None,
                 data: json!({"url": "https://example.com", "title": "Test Page"}),
             }
         }
@@ -704,6 +716,7 @@ mod tests {
                 event_type: "afk_change".to_string(),
                 stream_id: None,
                 session_id: None,
+                action: None,
                 data: json!({"status": status, "idle_duration_ms": idle_duration_ms}),
             }
         }
@@ -724,6 +737,10 @@ mod tests {
 
         fn session_id(&self) -> Option<&str> {
             self.session_id.as_deref()
+        }
+
+        fn action(&self) -> Option<&str> {
+            self.action.as_deref()
         }
 
         fn data(&self) -> &serde_json::Value {
@@ -993,6 +1010,7 @@ mod tests {
             event_type: "tmux_pane_focus".to_string(),
             stream_id: None, // Not assigned to any stream
             session_id: None,
+            action: None,
             data: json!({"pane_id": "%1"}),
         }];
 

--- a/docs/plans/2026-02-03-git-project-field.md
+++ b/docs/plans/2026-02-03-git-project-field.md
@@ -1,0 +1,306 @@
+# Git Project Field Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add explicit `git_project` and `git_workspace` fields to events so project names are correctly captured from git repository info rather than directory names.
+
+**Architecture:** Rename `jj_project`/`jj_workspace` → `git_project`/`git_workspace` throughout. Add explicit fields to `StoredEvent`. Remove the `#[serde(flatten)]` hack on the `data` field. Bump schema version (breaking change - old databases will fail to open).
+
+**Tech Stack:** Rust, SQLite, serde
+
+**Breaking Change:** This is intentionally backward-incompatible. Old databases will not open. Users must delete their database and re-sync from `events.jsonl`.
+
+---
+
+### Task 1: Rename fields in IngestEvent and helper function
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/ingest.rs`
+
+**Step 1: Rename struct fields (lines 38-44)**
+
+```rust
+    /// The git project name (from git remote origin).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_project: Option<String>,
+    /// The git workspace name (if in a non-default workspace).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_workspace: Option<String>,
+```
+
+**Step 2: Rename helper function (line 50)**
+
+```rust
+/// Get project identity for a directory using jj/git commands.
+fn get_git_identity(cwd: &std::path::Path) -> Option<ProjectIdentity> {
+```
+
+**Step 3: Update constructor (lines 109-121)**
+
+```rust
+        let git_identity = get_git_identity(Path::new(&cwd));
+
+        Self {
+            // ... other fields ...
+            git_project: git_identity.as_ref().map(|i| i.project_name.clone()),
+            git_workspace: git_identity.and_then(|i| i.workspace_name),
+        }
+```
+
+**Step 4: Update tests (lines 915-937)**
+
+```rust
+    assert_eq!(events[0].git_project, Some("my-project".to_string()));
+```
+and:
+```rust
+    assert_eq!(events[0].git_project, None);
+    assert_eq!(events[0].git_workspace, None);
+```
+
+**Step 5: Run tests**
+
+Run: `cargo test -p tt-cli ingest`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "refactor(ingest): rename jj_project to git_project"
+```
+
+---
+
+### Task 2: Add explicit fields to StoredEvent and remove flatten hack
+
+**Files:**
+- Modify: `crates/tt-db/src/lib.rs`
+
+**Step 1: Add explicit fields to StoredEvent (after line 142)**
+
+```rust
+    /// Git project name (from remote origin).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_project: Option<String>,
+
+    /// Git workspace name (if in a non-default workspace).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_workspace: Option<String>,
+```
+
+**Step 2: Remove the flatten hack (lines 134-138)**
+
+Delete:
+```rust
+    /// Type-specific JSON payload.
+    /// When deserializing, unknown fields are collected here via `#[serde(flatten)]`.
+    /// This allows both nested `data` format and flat format to work.
+    #[serde(default, flatten)]
+    pub data: serde_json::Value,
+```
+
+Replace with explicit tmux fields (since we know exactly what fields exist):
+```rust
+    /// Tmux pane ID (for tmux_pane_focus events).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_id: Option<String>,
+
+    /// Tmux session name (for tmux_pane_focus events).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tmux_session: Option<String>,
+
+    /// Tmux window index (for tmux_pane_focus events).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_index: Option<u32>,
+```
+
+**Step 3: Update InferableEvent impl (lines 183-185)**
+
+```rust
+    fn git_project(&self) -> Option<&str> {
+        self.git_project.as_deref()
+    }
+```
+
+**Step 4: Remove AllocatableEvent::data() method if no longer needed**
+
+Check if anything uses `event.data()` and remove or update accordingly.
+
+**Step 5: Run tests**
+
+Run: `cargo test -p tt-db`
+Expected: Some tests may fail if they rely on the `data` field - fix them
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "refactor(db): add explicit fields to StoredEvent, remove flatten hack"
+```
+
+---
+
+### Task 3: Update database schema (breaking change)
+
+**Files:**
+- Modify: `crates/tt-db/src/lib.rs`
+
+**Step 1: Bump schema version**
+
+Find `const SCHEMA_VERSION: i32 = 5;` and change to:
+```rust
+const SCHEMA_VERSION: i32 = 6;
+```
+
+**Step 2: Update CREATE TABLE (lines 293-310)**
+
+```sql
+CREATE TABLE IF NOT EXISTS events (
+    id TEXT PRIMARY KEY,
+    timestamp TEXT NOT NULL,
+    type TEXT NOT NULL,
+    source TEXT NOT NULL,
+    schema_version INTEGER DEFAULT 1,
+    cwd TEXT,
+    git_project TEXT,
+    git_workspace TEXT,
+    pane_id TEXT,
+    tmux_session TEXT,
+    window_index INTEGER,
+    session_id TEXT,
+    stream_id TEXT,
+    assignment_source TEXT DEFAULT 'inferred'
+);
+```
+
+**Step 3: Update INSERT statement**
+
+Find the insert_events function and update to include all new columns.
+
+**Step 4: Update SELECT statement**
+
+Find get_events and update to read all new columns.
+
+**Step 5: Remove any migration functions for old versions**
+
+Since this is a clean break, remove `migrate_from_v*` functions or simplify to just fail on old schemas.
+
+**Step 6: Run tests**
+
+Run: `cargo test -p tt-db`
+Expected: PASS
+
+**Step 7: Commit**
+
+```bash
+jj describe -m "feat(db): update schema to v6 with explicit event fields (breaking)"
+```
+
+---
+
+### Task 4: Rename trait method and update inference
+
+**Files:**
+- Modify: `crates/tt-core/src/inference.rs`
+
+**Step 1: Rename trait method (line 53)**
+
+```rust
+    fn git_project(&self) -> Option<&str>;
+```
+
+**Step 2: Update comments (lines 231, 240-241)**
+
+```rust
+/// - Prefers `git_project` from the first event if available
+...
+    // Try git_project from first event
+    let base_name = events.first().and_then(|e| e.git_project()).map_or_else(
+```
+
+**Step 3: Update test helper struct (lines 307-362)**
+
+```rust
+        git_project: Option<String>,
+...
+        fn with_git_project(mut self, project: &str) -> Self {
+            self.git_project = Some(project.to_string());
+            self
+        }
+...
+        fn git_project(&self) -> Option<&str> {
+            self.git_project.as_deref()
+        }
+```
+
+**Step 4: Rename all test functions (lines 591-660)**
+
+- `test_jj_project_preferred_over_directory` → `test_git_project_preferred_over_directory`
+- `test_fallback_to_directory_without_jj_project` → `test_fallback_to_directory_without_git_project`
+- `test_jj_project_same_name_different_directories` → `test_git_project_same_name_different_directories`
+- `test_mixed_jj_project_and_no_jj_project` → `test_mixed_git_project_and_no_git_project`
+
+Update all `.with_jj_project(` to `.with_git_project(` in test bodies.
+
+**Step 5: Run tests**
+
+Run: `cargo test -p tt-core`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "refactor(core): rename jj_project to git_project in inference"
+```
+
+---
+
+### Task 5: Final verification and cleanup
+
+**Step 1: Search for any remaining jj_project references**
+
+Run: `grep -r "jj_project" crates/`
+Expected: No matches
+
+**Step 2: Update project.rs doc comment (line 1)**
+
+```rust
+//! Git project identity extraction.
+```
+
+**Step 3: Run full test suite**
+
+Run: `cargo test`
+Expected: PASS
+
+**Step 4: Run clippy**
+
+Run: `cargo clippy --all-targets`
+Expected: No warnings
+
+**Step 5: Test end-to-end**
+
+```bash
+# Delete old database (breaking change)
+rm -f ~/.local/share/tt/events.db
+
+# Ingest a test event
+cargo run -- ingest --pane-id %999 --tmux-session test --cwd /home/sami/time-tracker/default
+
+# Check the events file
+tail -1 ~/.time-tracker/events.jsonl | jq '{git_project, git_workspace, cwd}'
+
+# Import and verify
+cargo run -- import < ~/.time-tracker/events.jsonl
+cargo run -- events | tail -1 | jq '{git_project, git_workspace}'
+```
+
+Expected: `git_project` and `git_workspace` fields present and round-trip correctly.
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat: rename jj_project to git_project for proper project identification
+
+BREAKING CHANGE: Schema version bumped to 6. Old databases will not open.
+Delete ~/.local/share/tt/events.db and re-import from events.jsonl."
+```


### PR DESCRIPTION
## Summary

Renames `jj_project`/`jj_workspace` fields to `git_project`/`git_workspace` throughout the codebase. These fields identify the git repository context for events, not jj-specific information.

**Breaking change:** Database schema updated from v5 to v6. Requires deleting existing database.

## Changes

- **tt-cli/ingest.rs**: Renamed fields in `IngestEvent`, renamed `get_jj_identity()` to `get_git_identity()`
- **tt-db/lib.rs**: Added explicit fields to `StoredEvent` (replacing `#[serde(flatten)]` hack), bumped schema to v6, added `action` column
- **tt-core/allocation.rs**: Added `action()` method to `AllocatableEvent` trait
- **tt-core/inference.rs**: Renamed `jj_project()` to `git_project()` in `InferableEvent` trait
- **tt-core/project.rs**: Fixed `parse_remote_name()` bug with SSH URLs, updated docs

## Test Plan

- [x] All 339 tests pass
- [x] Clippy clean (no warnings)
- [x] End-to-end verification: `git_project`/`git_workspace` fields round-trip correctly through ingest → database → export