### PR TITLE
ci: split workflow into parallel lint and build jobs

### DIFF
--- a/.github/workflows/pr-and-main.yml
+++ b/.github/workflows/pr-and-main.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    name: Quality Checks
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,30 +19,25 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - uses: taiki-e/install-action@cargo-deny
+
+      - run: cargo fmt --check
+      - run: cargo deny check
+
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          components: clippy
 
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+      - uses: Swatinem/rust-cache@v2
 
-      - name: Check formatting
-        run: cargo fmt --check
-
-      - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
-
-      - name: Run tests
-        run: cargo test
-
-      - name: Check dependencies
-        run: cargo deny check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test


### PR DESCRIPTION
## Summary

Splits the CI workflow into two parallel jobs for faster feedback:

- **lint**: `fmt --check` + `cargo deny` (fast, no compilation)
- **build-and-test**: `clippy` + `test` (share compilation artifacts)

This gives granular PR status checks while avoiding duplicate compilation.