### PR TITLE
feat: add OpenCode session ingestion with unified AgentSession model

### DIFF
--- a/.claude/skills/infer-streams/SKILL.md
+++ b/.claude/skills/infer-streams/SKILL.md
@@ -24,13 +24,21 @@ Optional: Time range (default: "8 hours ago")
 
 Example: `/infer-streams 3 days ago`
 
-## Phase 1: Gather Context
+## Phase 1: Run Ingestion
+
+**CRITICAL: Always run ingestion before gathering context.** Without this, `tt context` returns stale/incomplete data — you may miss 75%+ of sessions.
+
+```bash
+cargo build 2>/dev/null && cargo run -- ingest sessions
+```
+
+## Phase 2: Gather Context
 
 ```bash
 tt context --events --agents --streams --gaps --start "{time_range}"
 ```
 
-## Phase 2: Identify Projects
+## Phase 3: Identify Projects
 
 **Extract project from path:**
 - `/home/sami/pivot` → project: `pivot`
@@ -41,7 +49,7 @@ tt context --events --agents --streams --gaps --start "{time_range}"
 **Detect renamed directories:**
 - If two directories have similar content/activity patterns but different names, they may be the same project renamed
 
-## Phase 3: Identify Streams Within Projects
+## Phase 4: Identify Streams Within Projects
 
 For each project, identify distinct streams using:
 
@@ -67,7 +75,7 @@ For each project, identify distinct streams using:
 - "legion: controller implementation"
 - "time-tracker: stream inference feature"
 
-## Phase 4: Calculate Time
+## Phase 5: Calculate Time
 
 **All times reported in Pacific Time (UTC-8).**
 
@@ -90,7 +98,7 @@ Calculation:
 - Example: 3 agents × 10 min = 30 agent-minutes
 - Track `parent_session_id` to identify subagents
 
-## Phase 5: Output Report
+## Phase 6: Output Report
 
 **All times in Pacific Time.**
 
@@ -135,6 +143,7 @@ For each stream, brief summary:
 
 | Mistake | Fix |
 |---------|-----|
+| Skipping ingestion | **Always** run `tt ingest sessions` before `tt context`. Without it you miss most data. |
 | Treating project as stream | Project = repo. Stream = task/feature within repo |
 | Splitting subdirectories as different projects | `/pivot/agents` is part of `pivot`, not a separate project |
 | Streams too coarse ("pivot work") | Use task-specific names ("pivot: execution engine refactor") |

--- a/crates/tt-cli/src/cli.rs
+++ b/crates/tt-cli/src/cli.rs
@@ -214,8 +214,10 @@ pub enum IngestEvent {
         window: Option<u32>,
     },
 
-    /// Index Claude Code sessions from ~/.claude/projects/.
+    /// Index coding assistant sessions.
     ///
-    /// Scans session JSONL files and stores metadata in the database.
+    /// Scans Claude Code (~/.claude/projects/) and `OpenCode`
+    /// (~/.local/share/opencode/storage/) session files and stores
+    /// metadata in the database.
     Sessions,
 }

--- a/crates/tt-core/src/lib.rs
+++ b/crates/tt-core/src/lib.rs
@@ -11,6 +11,7 @@
 mod allocation;
 mod event;
 pub mod inference;
+pub mod opencode;
 pub mod project;
 pub mod session;
 mod stream;
@@ -25,7 +26,8 @@ pub use inference::{
     InferableEvent, InferenceConfig, InferenceResult, InferredStream, StreamAssignment,
     infer_streams,
 };
-pub use session::SessionType;
+pub use opencode::scan_opencode_sessions;
+pub use session::{AgentSession, SessionSource, SessionType};
 pub use stream::Stream;
 pub use suggest::{Suggestion, is_metadata_ambiguous, suggest_from_metadata};
 pub use types::{AssignmentSource, Confidence, EventId, SessionId, StreamId, ValidationError};

--- a/crates/tt-core/src/opencode.rs
+++ b/crates/tt-core/src/opencode.rs
@@ -1,0 +1,744 @@
+//! `OpenCode` session parsing.
+
+use std::fs;
+use std::path::Path;
+
+use chrono::{DateTime, TimeZone, Utc};
+use rayon::prelude::*;
+use serde::Deserialize;
+
+use crate::session::{
+    AgentSession, MAX_USER_MESSAGE_TIMESTAMPS, MAX_USER_PROMPTS, SessionError, SessionSource,
+    SessionType, extract_project_name, truncate_prompt,
+};
+
+/// `OpenCode` session metadata.
+#[derive(Debug, Deserialize)]
+struct OpenCodeSession {
+    id: String,
+    directory: String,
+    title: Option<String>,
+    #[serde(rename = "parentID")]
+    parent_id: Option<String>,
+    time: OpenCodeTime,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeTime {
+    created: i64,
+    updated: Option<i64>,
+}
+
+/// `OpenCode` message role.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum MessageRole {
+    User,
+    Assistant,
+    #[serde(other)]
+    Other,
+}
+
+/// `OpenCode` message metadata.
+#[derive(Debug, Deserialize)]
+struct OpenCodeMessage {
+    id: String,
+    role: MessageRole,
+    time: OpenCodeMessageTime,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeMessageTime {
+    created: i64,
+}
+
+/// `OpenCode` message part type.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum PartType {
+    Text,
+    Tool,
+    #[serde(other)]
+    Other,
+}
+
+/// `OpenCode` message part.
+#[derive(Debug, Deserialize)]
+struct OpenCodePart {
+    /// Part ID -- used for deterministic ordering since `read_json_files`
+    /// returns entries in filesystem-dependent order.
+    id: String,
+    #[serde(rename = "type")]
+    part_type: PartType,
+    text: Option<String>,
+}
+
+fn unix_ms_to_datetime(ms: i64) -> Option<DateTime<Utc>> {
+    Utc.timestamp_millis_opt(ms).single()
+}
+
+/// Read and deserialize all JSON files from a directory.
+fn read_json_files<T: serde::de::DeserializeOwned>(dir: &Path) -> Vec<T> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    entries
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .filter_map(|e| {
+            let path = e.path();
+            let data = match fs::read_to_string(&path) {
+                Ok(d) => d,
+                Err(err) => {
+                    tracing::warn!(path = ?path, error = %err, "failed to read JSON file");
+                    return None;
+                }
+            };
+            match serde_json::from_str(&data) {
+                Ok(v) => Some(v),
+                Err(err) => {
+                    tracing::warn!(path = ?path, error = %err, "failed to parse JSON file");
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
+/// Parse an `OpenCode` session from its session file.
+pub fn parse_opencode_session(
+    storage_dir: &Path,
+    session_file: &Path,
+) -> Result<AgentSession, SessionError> {
+    let data = fs::read_to_string(session_file)?;
+    let session: OpenCodeSession = serde_json::from_str(&data)?;
+
+    if session.id.is_empty() {
+        return Err(SessionError::EmptySessionId);
+    }
+
+    let message_dir = storage_dir.join("message").join(&session.id);
+
+    let mut messages: Vec<OpenCodeMessage> = read_json_files(&message_dir);
+    messages.sort_by_key(|m| m.time.created);
+
+    let mut user_message_count = 0i32;
+    let mut assistant_message_count = 0i32;
+    let mut tool_call_count = 0i32;
+    let mut user_prompts: Vec<String> = Vec::new();
+    let mut starting_prompt: Option<String> = None;
+    let mut user_message_timestamps: Vec<DateTime<Utc>> = Vec::new();
+    let mut last_message_time: Option<i64> = None;
+
+    for msg in &messages {
+        last_message_time = Some(msg.time.created);
+
+        let mut parts: Vec<OpenCodePart> = match msg.role {
+            MessageRole::User | MessageRole::Assistant => {
+                read_json_files(&storage_dir.join("part").join(&msg.id))
+            }
+            MessageRole::Other => continue,
+        };
+        // Sort by ID for deterministic ordering (fs::read_dir order is platform-dependent)
+        parts.sort_by(|a, b| a.id.cmp(&b.id));
+
+        match msg.role {
+            MessageRole::User => {
+                user_message_count = user_message_count.saturating_add(1);
+
+                let text: String = parts
+                    .iter()
+                    .filter(|p| p.part_type == PartType::Text)
+                    .filter_map(|p| p.text.as_deref())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                if !text.is_empty() {
+                    if starting_prompt.is_none() {
+                        starting_prompt = Some(truncate_prompt(&text));
+                    }
+                    if user_prompts.len() < MAX_USER_PROMPTS {
+                        user_prompts.push(truncate_prompt(&text));
+                    }
+                    if user_message_timestamps.len() < MAX_USER_MESSAGE_TIMESTAMPS {
+                        if let Some(ts) = unix_ms_to_datetime(msg.time.created) {
+                            user_message_timestamps.push(ts);
+                        }
+                    }
+                }
+            }
+            MessageRole::Assistant => {
+                assistant_message_count = assistant_message_count.saturating_add(1);
+
+                let count = parts
+                    .iter()
+                    .filter(|p| p.part_type == PartType::Tool)
+                    .count();
+                tool_call_count =
+                    tool_call_count.saturating_add(i32::try_from(count).unwrap_or(i32::MAX));
+            }
+            MessageRole::Other => unreachable!(),
+        }
+    }
+
+    let message_count = user_message_count.saturating_add(assistant_message_count);
+    let start_time = unix_ms_to_datetime(session.time.created)
+        .ok_or(SessionError::InvalidTimestamp(session.time.created))?;
+
+    // end_time: latest of last message time or session updated time
+    let end_ms = match (last_message_time, session.time.updated) {
+        (Some(msg), Some(upd)) => Some(msg.max(upd)),
+        (any, other) => any.or(other),
+    };
+    let end_time = end_ms
+        .and_then(unix_ms_to_datetime)
+        .filter(|t| *t > start_time);
+
+    let session_type = if session.parent_id.is_some() {
+        SessionType::Subagent
+    } else {
+        SessionType::User
+    };
+
+    let project_name = extract_project_name(&session.directory);
+
+    Ok(AgentSession {
+        session_id: session.id,
+        source: SessionSource::OpenCode,
+        parent_session_id: session.parent_id,
+        session_type,
+        project_path: session.directory,
+        project_name,
+        start_time,
+        end_time,
+        message_count,
+        summary: session.title,
+        user_prompts,
+        starting_prompt,
+        assistant_message_count,
+        tool_call_count,
+        user_message_timestamps,
+    })
+}
+
+/// Scan `OpenCode` storage directory for sessions.
+pub fn scan_opencode_sessions(storage_dir: &Path) -> Result<Vec<AgentSession>, SessionError> {
+    let session_dir = storage_dir.join("session");
+    if !session_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut session_files = Vec::new();
+
+    for project_entry in fs::read_dir(&session_dir)? {
+        let project_path = project_entry?.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        for session_entry in fs::read_dir(&project_path)? {
+            let session_path = session_entry?.path();
+            if session_path.extension().is_some_and(|e| e == "json") {
+                session_files.push(session_path);
+            }
+        }
+    }
+
+    let mut sessions: Vec<AgentSession> = session_files
+        .par_iter()
+        .filter_map(|path| match parse_opencode_session(storage_dir, path) {
+            Ok(session) => Some(session),
+            Err(e) => {
+                tracing::warn!(path = ?path, error = %e, "skipping invalid OpenCode session");
+                None
+            }
+        })
+        .collect();
+
+    sessions.sort_by_key(|e| e.start_time);
+    Ok(sessions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Create a minimal `OpenCode` session fixture.
+    #[expect(clippy::too_many_arguments, reason = "test fixture helper")]
+    fn create_session_fixture(
+        storage_dir: &Path,
+        project_hash: &str,
+        session_id: &str,
+        directory: &str,
+        title: Option<&str>,
+        parent_id: Option<&str>,
+        created_ms: i64,
+        updated_ms: Option<i64>,
+    ) -> std::path::PathBuf {
+        let session_dir = storage_dir.join("session").join(project_hash);
+        fs::create_dir_all(&session_dir).unwrap();
+
+        let session_data = serde_json::json!({
+            "id": session_id,
+            "directory": directory,
+            "title": title,
+            "parentID": parent_id,
+            "time": {
+                "created": created_ms,
+                "updated": updated_ms,
+            }
+        });
+
+        let path = session_dir.join(format!("{session_id}.json"));
+        fs::write(&path, serde_json::to_string(&session_data).unwrap()).unwrap();
+        path
+    }
+
+    fn create_message_fixture(
+        storage_dir: &Path,
+        session_id: &str,
+        message_id: &str,
+        role: &str,
+        created_ms: i64,
+    ) {
+        let msg_dir = storage_dir.join("message").join(session_id);
+        fs::create_dir_all(&msg_dir).unwrap();
+
+        let msg_data = serde_json::json!({
+            "id": message_id,
+            "sessionID": session_id,
+            "role": role,
+            "time": { "created": created_ms }
+        });
+
+        fs::write(
+            msg_dir.join(format!("{message_id}.json")),
+            serde_json::to_string(&msg_data).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn create_part_fixture(
+        storage_dir: &Path,
+        message_id: &str,
+        part_id: &str,
+        part_type: &str,
+        text: Option<&str>,
+    ) {
+        let part_dir = storage_dir.join("part").join(message_id);
+        fs::create_dir_all(&part_dir).unwrap();
+
+        let mut part_data = serde_json::json!({
+            "id": part_id,
+            "type": part_type,
+        });
+        if let Some(t) = text {
+            part_data["text"] = serde_json::Value::String(t.to_string());
+        }
+
+        fs::write(
+            part_dir.join(format!("{part_id}.json")),
+            serde_json::to_string(&part_data).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_parse_basic_session() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_test1",
+            "/home/user/my-project",
+            Some("Test session"),
+            None,
+            1_700_000_000_000,
+            Some(1_700_000_060_000),
+        );
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+
+        assert_eq!(session.session_id, "ses_test1");
+        assert_eq!(session.source, SessionSource::OpenCode);
+        assert_eq!(session.session_type, SessionType::User);
+        assert_eq!(session.project_path, "/home/user/my-project");
+        assert_eq!(session.project_name, "my-project");
+        assert_eq!(session.summary.as_deref(), Some("Test session"));
+        assert_eq!(session.message_count, 0);
+        // end_time should come from session.time.updated when no messages
+        assert_eq!(session.end_time, unix_ms_to_datetime(1_700_000_060_000));
+    }
+
+    #[test]
+    fn test_parse_session_with_messages() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_msg",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            None,
+        );
+
+        // User message
+        create_message_fixture(storage, "ses_msg", "msg_u1", "user", 1_700_000_001_000);
+        create_part_fixture(storage, "msg_u1", "prt_u1", "text", Some("hello world"));
+
+        // Assistant message with tool
+        create_message_fixture(storage, "ses_msg", "msg_a1", "assistant", 1_700_000_002_000);
+        create_part_fixture(storage, "msg_a1", "prt_a1_text", "text", Some("I'll help"));
+        create_part_fixture(storage, "msg_a1", "prt_a1_tool", "tool", None);
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+
+        assert_eq!(session.message_count, 2);
+        assert_eq!(session.assistant_message_count, 1);
+        assert_eq!(session.tool_call_count, 1);
+        assert_eq!(session.user_prompts, vec!["hello world"]);
+        assert_eq!(session.starting_prompt.as_deref(), Some("hello world"));
+        assert_eq!(session.user_message_timestamps.len(), 1);
+        assert!(session.end_time.is_some());
+    }
+
+    #[test]
+    fn test_parse_subagent_session() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_child",
+            "/home/user/project",
+            None,
+            Some("ses_parent"),
+            1_700_000_000_000,
+            None,
+        );
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+
+        assert_eq!(session.session_type, SessionType::Subagent);
+        assert_eq!(session.parent_session_id.as_deref(), Some("ses_parent"));
+    }
+
+    #[test]
+    fn test_parse_session_missing_messages_dir() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_empty",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            None,
+        );
+
+        // No message dir created
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+
+        assert_eq!(session.message_count, 0);
+        assert!(session.user_prompts.is_empty());
+        assert!(session.end_time.is_none());
+    }
+
+    #[test]
+    fn test_scan_opencode_sessions() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        create_session_fixture(
+            storage,
+            "proj1",
+            "ses_a",
+            "/home/user/project-a",
+            None,
+            None,
+            1_700_000_000_000,
+            None,
+        );
+        create_session_fixture(
+            storage,
+            "proj2",
+            "ses_b",
+            "/home/user/project-b",
+            None,
+            None,
+            1_700_000_100_000,
+            None,
+        );
+
+        let sessions = scan_opencode_sessions(storage).unwrap();
+
+        assert_eq!(sessions.len(), 2);
+        // Sorted by start_time
+        assert_eq!(sessions[0].session_id, "ses_a");
+        assert_eq!(sessions[1].session_id, "ses_b");
+    }
+
+    #[test]
+    fn test_scan_nonexistent_dir() {
+        let result = scan_opencode_sessions(Path::new("/nonexistent")).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_user_prompts_limited() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_many",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            None,
+        );
+
+        for i in 0..10 {
+            let msg_id = format!("msg_u{i}");
+            let part_id = format!("prt_u{i}");
+            create_message_fixture(
+                storage,
+                "ses_many",
+                &msg_id,
+                "user",
+                1_700_000_000_000 + i64::from(i) * 1000,
+            );
+            create_part_fixture(
+                storage,
+                &msg_id,
+                &part_id,
+                "text",
+                Some(&format!("prompt {i}")),
+            );
+        }
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+
+        assert_eq!(session.user_prompts.len(), MAX_USER_PROMPTS);
+        assert_eq!(session.starting_prompt.as_deref(), Some("prompt 0"));
+    }
+
+    #[test]
+    fn test_parse_session_with_invalid_timestamp() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        // Use an out-of-range timestamp (i64::MAX milliseconds)
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_bad_ts",
+            "/home/user/project",
+            None,
+            None,
+            i64::MAX,
+            None,
+        );
+
+        let result = parse_opencode_session(storage, &session_file);
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), SessionError::InvalidTimestamp(ts) if ts == i64::MAX)
+        );
+    }
+
+    #[test]
+    fn test_end_time_none_when_equal_to_start_time() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        // updated == created → end_time should be None
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_same_ts",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            Some(1_700_000_000_000),
+        );
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+        assert!(session.end_time.is_none());
+    }
+
+    #[test]
+    fn test_end_time_from_last_message_beats_updated() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        // session.updated is earlier than last message
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_msg_later",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            Some(1_700_000_010_000),
+        );
+
+        create_message_fixture(storage, "ses_msg_later", "msg_1", "user", 1_700_000_020_000);
+        create_part_fixture(storage, "msg_1", "prt_1", "text", Some("hi"));
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+        // end_time should be from last message (20s), not session.updated (10s)
+        assert_eq!(session.end_time, unix_ms_to_datetime(1_700_000_020_000));
+    }
+
+    #[test]
+    fn test_parse_session_malformed_json_file() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_dir = storage.join("session").join("proj1");
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(session_dir.join("bad.json"), "not valid json").unwrap();
+
+        let result = parse_opencode_session(storage, &session_dir.join("bad.json"));
+        assert!(matches!(result, Err(SessionError::Json(_))));
+    }
+
+    #[test]
+    fn test_parse_session_missing_required_fields() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_dir = storage.join("session").join("proj1");
+        fs::create_dir_all(&session_dir).unwrap();
+        // Valid JSON but missing required fields (no id, directory, time)
+        fs::write(session_dir.join("incomplete.json"), r#"{"title": "test"}"#).unwrap();
+
+        let result = parse_opencode_session(storage, &session_dir.join("incomplete.json"));
+        assert!(matches!(result, Err(SessionError::Json(_))));
+    }
+
+    #[test]
+    fn test_scan_skips_malformed_sessions() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        // One good session
+        create_session_fixture(
+            storage,
+            "proj1",
+            "ses_good",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            None,
+        );
+
+        // One bad session (invalid JSON)
+        let bad_dir = storage.join("session").join("proj1");
+        fs::write(bad_dir.join("ses_bad.json"), "not json").unwrap();
+
+        let sessions = scan_opencode_sessions(storage).unwrap();
+        // Should only contain the good session
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "ses_good");
+    }
+
+    #[test]
+    fn test_parse_session_with_messages_verifies_end_time() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_verify_end",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            None,
+        );
+
+        create_message_fixture(
+            storage,
+            "ses_verify_end",
+            "msg_u1",
+            "user",
+            1_700_000_001_000,
+        );
+        create_part_fixture(storage, "msg_u1", "prt_u1", "text", Some("hello"));
+        create_message_fixture(
+            storage,
+            "ses_verify_end",
+            "msg_a1",
+            "assistant",
+            1_700_000_005_000,
+        );
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+
+        // end_time should be the last message's timestamp
+        assert_eq!(session.end_time, unix_ms_to_datetime(1_700_000_005_000));
+    }
+
+    #[test]
+    fn test_end_time_none_when_updated_before_created() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        // session.updated < session.created (clock skew or data corruption)
+        let session_file = create_session_fixture(
+            storage,
+            "proj1",
+            "ses_skew",
+            "/home/user/project",
+            None,
+            None,
+            1_700_000_000_000,
+            Some(1_699_999_000_000), // 1000 seconds before created
+        );
+
+        let session = parse_opencode_session(storage, &session_file).unwrap();
+        assert!(
+            session.end_time.is_none(),
+            "end_time should be None when updated is before created"
+        );
+    }
+
+    #[test]
+    fn test_empty_session_id_rejected() {
+        let temp = TempDir::new().unwrap();
+        let storage = temp.path();
+
+        let session_dir = storage.join("session").join("proj1");
+        fs::create_dir_all(&session_dir).unwrap();
+
+        let data = serde_json::json!({
+            "id": "",
+            "directory": "/home/user/project",
+            "time": { "created": 1_700_000_000_000i64 }
+        });
+        let path = session_dir.join("empty_id.json");
+        fs::write(&path, serde_json::to_string(&data).unwrap()).unwrap();
+
+        let result = parse_opencode_session(storage, &path);
+        assert!(matches!(result, Err(SessionError::EmptySessionId)));
+    }
+}

--- a/docs/plans/2026-02-05-opencode-session-ingestion-plan.md
+++ b/docs/plans/2026-02-05-opencode-session-ingestion-plan.md
@@ -1,0 +1,416 @@
+# OpenCode Session Ingestion Implementation Plan
+
+**Goal:** Extend session ingestion to support both Claude Code and OpenCode with a unified `AgentSession` model.
+
+**Design:** See `2026-02-05-opencode-session-ingestion.md`
+
+**Breaking change (pre-alpha):** No migration/backfill. Existing `claude_sessions` data is discarded; re-ingest required (delete DB if needed).
+
+---
+
+## Task 1: Add SessionSource Enum
+
+**Files:**
+- Modify: `crates/tt-core/src/session.rs`
+
+**Step 1:** Add `SessionSource` enum after `SessionType`:
+
+```rust
+/// Source of the coding session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionSource {
+    #[default]
+    Claude,
+    OpenCode,
+}
+
+impl SessionSource {
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::OpenCode => "opencode",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SessionSource {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "claude" => Ok(Self::Claude),
+            "opencode" => Ok(Self::OpenCode),
+            _ => Err(format!("invalid session source: {s}")),
+        }
+    }
+}
+```
+
+---
+
+## Task 2: Rename ClaudeSession to AgentSession
+
+**Files:**
+- Modify: `crates/tt-core/src/session.rs`
+- Modify: `crates/tt-core/src/lib.rs`
+
+**Step 1:** In `session.rs`, rename the struct and field:
+
+- `ClaudeSession` → `AgentSession`
+- `claude_session_id` → `session_id`
+- Add `source: SessionSource` field after `session_id`
+
+```rust
+/// An indexed coding assistant session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSession {
+    pub session_id: String,
+    /// Source tool (Claude Code or OpenCode).
+    #[serde(default)]
+    pub source: SessionSource,
+    pub parent_session_id: Option<String>,
+    // ... rest unchanged
+}
+```
+
+**Step 2:** Update `parse_session_file` to set `source: SessionSource::Claude` and use `session_id` parameter name.
+
+**Step 3:** Update `lib.rs` exports:
+```rust
+pub use session::{AgentSession, SessionSource, SessionType, parse_session_file, scan_claude_sessions, extract_project_name};
+```
+
+**Step 4:** Fix all test struct initializations to use new names and add `source` field.
+
+---
+
+## Task 3: Update tt-db Schema
+
+**Files:**
+- Modify: `crates/tt-db/src/lib.rs`
+
+**Step 1:** Increment `SCHEMA_VERSION` (next version).
+
+Session IDs have distinct formats per source (Claude: UUIDs or `agent-*`, OpenCode: `ses_*`), so no collision is possible. Single-column primary key is sufficient.
+
+**Step 2:** Update table creation SQL - rename `claude_sessions` to `agent_sessions`, rename `claude_session_id` to `session_id`, add `source` column:
+
+```sql
+CREATE TABLE IF NOT EXISTS agent_sessions (
+    session_id TEXT PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'claude',
+    parent_session_id TEXT,
+    session_type TEXT NOT NULL DEFAULT 'user',
+    project_path TEXT NOT NULL,
+    project_name TEXT NOT NULL,
+    start_time TEXT NOT NULL,
+    end_time TEXT,
+    message_count INTEGER NOT NULL,
+    summary TEXT,
+    user_prompts TEXT DEFAULT '[]',
+    starting_prompt TEXT,
+    assistant_message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_start_time ON agent_sessions(start_time);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_project_path ON agent_sessions(project_path);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_parent ON agent_sessions(parent_session_id);
+```
+
+**Step 3:** Rename methods:
+- `upsert_claude_session` → `upsert_agent_session`
+- `claude_sessions_in_range` → `agent_sessions_in_range`
+- Update SQL in these methods to use new table/column names
+
+**Step 4:** Update method signatures to use `AgentSession` and include `source` in INSERT/SELECT.
+
+---
+
+## Task 4: Create OpenCode Parser Module
+
+**Files:**
+- Create: `crates/tt-core/src/opencode.rs`
+- Modify: `crates/tt-core/src/lib.rs`
+
+**Step 1:** Create `opencode.rs` with structs for OpenCode JSON format:
+
+```rust
+//! OpenCode session parsing.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use chrono::{DateTime, TimeZone, Utc};
+use rayon::prelude::*;
+use serde::Deserialize;
+
+use crate::session::{AgentSession, SessionError, SessionSource, SessionType, extract_project_name};
+
+/// OpenCode session metadata.
+#[derive(Debug, Deserialize)]
+struct OpenCodeSession {
+    id: String,
+    directory: String,
+    title: Option<String>,
+    #[serde(rename = "parentID")]
+    parent_id: Option<String>,
+    time: OpenCodeTime,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeTime {
+    created: i64,  // unix ms
+    updated: Option<i64>,
+}
+
+/// OpenCode message metadata.
+#[derive(Debug, Deserialize)]
+struct OpenCodeMessage {
+    id: String,
+    role: String,
+    time: OpenCodeMessageTime,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeMessageTime {
+    created: i64,
+}
+
+/// OpenCode message part.
+#[derive(Debug, Deserialize)]
+struct OpenCodePart {
+    #[serde(rename = "type")]
+    part_type: String,
+    text: Option<String>,
+}
+```
+
+**Step 2:** Add parsing function:
+
+```rust
+/// Maximum user prompts to extract.
+const MAX_USER_PROMPTS: usize = 5;
+const MAX_PROMPT_LENGTH: usize = 2000;
+const MAX_USER_MESSAGE_TIMESTAMPS: usize = 1000;
+
+fn truncate_prompt(content: &str) -> String {
+    if content.len() <= MAX_PROMPT_LENGTH {
+        return content.to_string();
+    }
+    let mut end = MAX_PROMPT_LENGTH;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &content[..end])
+}
+
+fn unix_ms_to_datetime(ms: i64) -> DateTime<Utc> {
+    Utc.timestamp_millis_opt(ms).single().unwrap_or_else(Utc::now)
+}
+
+pub fn parse_opencode_session(
+    storage_dir: &Path,
+    session_file: &Path,
+) -> Result<AgentSession, SessionError> {
+    // Implementation: read session, messages, parts
+    // Return AgentSession with source: SessionSource::OpenCode
+    todo!()
+}
+```
+
+Reuse `SessionError` (extend with OpenCode-specific variants only if needed).
+
+**Step 3:** Add scanner function:
+
+```rust
+/// Scan OpenCode storage directory for sessions.
+pub fn scan_opencode_sessions(storage_dir: &Path) -> Result<Vec<AgentSession>, SessionError> {
+    let session_dir = storage_dir.join("session");
+    if !session_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut session_files = Vec::new();
+    
+    // Collect all session files
+    for project_entry in fs::read_dir(&session_dir)? {
+        let project_path = project_entry?.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        for session_entry in fs::read_dir(&project_path)? {
+            let session_path = session_entry?.path();
+            if session_path.extension().is_some_and(|e| e == "json") {
+                session_files.push(session_path);
+            }
+        }
+    }
+
+    // Parse in parallel
+    let sessions: Vec<AgentSession> = session_files
+        .par_iter()
+        .filter_map(|path| {
+            parse_opencode_session(storage_dir, path).ok()
+        })
+        .collect();
+
+    Ok(sessions)
+}
+```
+
+**Step 4:** Add to `lib.rs`:
+```rust
+pub mod opencode;
+pub use opencode::scan_opencode_sessions;
+```
+
+**Step 5:** Write unit tests with sample data.
+
+---
+
+## Task 5: Implement OpenCode Parser Logic
+
+**Files:**
+- Modify: `crates/tt-core/src/opencode.rs`
+
+**Step 1:** Implement `parse_opencode_session`:
+
+1. Read session JSON file
+2. Read all message files from `message/{session_id}/`
+3. For each user message, read parts from `part/{message_id}/`
+4. Count assistant messages and tool parts
+5. Build and return `AgentSession`
+6. Use session `time.created` for `start_time`; `end_time` from last message or `time.updated`
+
+**Step 2:** Handle edge cases:
+- Missing message directories: treat as empty session (message count 0) and use session timestamps
+- Missing part directories: ignore parts for that message
+- Malformed JSON files: skip session with a warning
+- Empty sessions: allow (message count 0, no prompts)
+- Sort messages by `time.created` before counting/extracting prompts
+
+---
+
+## Task 6: Update CLI Ingest Command
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/ingest.rs`
+
+**Step 1:** Update imports:
+```rust
+use tt_core::session::{AgentSession, scan_claude_sessions};
+use tt_core::opencode::scan_opencode_sessions;
+```
+
+**Step 2:** Rename `index_sessions` internals:
+- `scan_claude_sessions` stays as-is
+- Add call to `scan_opencode_sessions`
+- Combine results
+
+**Step 3:** Update `get_claude_projects_dir` → keep for Claude, add `get_opencode_storage_dir`:
+```rust
+fn get_opencode_storage_dir() -> Result<PathBuf> {
+    let home = std::env::var("HOME").context("HOME environment variable not set")?;
+    Ok(PathBuf::from(home).join(".local/share/opencode/storage"))
+}
+```
+
+**Step 4:** Update `index_sessions` to scan both:
+```rust
+pub fn index_sessions(db: &tt_db::Database) -> Result<()> {
+    let mut all_sessions = Vec::new();
+    
+    // Claude Code
+    let claude_dir = get_claude_projects_dir()?;
+    if claude_dir.exists() {
+        println!("Scanning Claude Code sessions...");
+        let claude_sessions = scan_claude_sessions(&claude_dir)?;
+        println!("  Found {} Claude sessions", claude_sessions.len());
+        all_sessions.extend(claude_sessions);
+    }
+    
+    // OpenCode
+    let opencode_dir = get_opencode_storage_dir()?;
+    if opencode_dir.exists() {
+        println!("Scanning OpenCode sessions...");
+        let opencode_sessions = scan_opencode_sessions(&opencode_dir)?;
+        println!("  Found {} OpenCode sessions", opencode_sessions.len());
+        all_sessions.extend(opencode_sessions);
+    }
+    
+    // ... rest of indexing logic
+}
+```
+
+**Step 5:** Update `create_session_events` to use `AgentSession` and set event source based on `session.source`.
+
+**Step 6:** Update database calls to use renamed methods.
+
+---
+
+## Task 7: Update Remaining References
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/context.rs` (if it uses ClaudeSession)
+- Modify: any other files referencing old names
+
+**Step 1:** Search for remaining references:
+```bash
+rg "ClaudeSession|claude_session_id|claude_sessions" crates/
+```
+
+**Step 2:** Update each reference to new names.
+
+---
+
+## Task 8: Final Verification
+
+**Step 1:** Run all checks:
+```bash
+cargo clippy --all-targets
+cargo fmt --check
+cargo test --all
+```
+
+**Step 2:** Manual verification:
+```bash
+cargo run -- ingest sessions
+```
+
+**Step 3:** Verify output shows both sources:
+```
+Scanning Claude Code sessions...
+  Found 120 Claude sessions
+Scanning OpenCode sessions...
+  Found 30 OpenCode sessions
+Indexed 150 sessions (X events)
+```
+
+**Step 4:** Query to verify data:
+```bash
+cargo run -- context --days 1
+```
+
+---
+
+## Summary
+
+| Task | Description | Crate |
+|------|-------------|-------|
+| 1 | Add `SessionSource` enum | tt-core |
+| 2 | Rename `ClaudeSession` → `AgentSession` | tt-core |
+| 3 | Update database schema (agent_sessions table) | tt-db |
+| 4 | Create OpenCode parser module (skeleton) | tt-core |
+| 5 | Implement OpenCode parser logic | tt-core |
+| 6 | Update CLI ingest command | tt-cli |
+| 7 | Update remaining references | all |
+| 8 | Final verification | - |

--- a/docs/plans/2026-02-05-opencode-session-ingestion.md
+++ b/docs/plans/2026-02-05-opencode-session-ingestion.md
@@ -1,0 +1,147 @@
+# OpenCode Session Ingestion Design
+
+**Goal:** Extend session ingestion to support both Claude Code and OpenCode, using a unified `AgentSession` model.
+
+**Date:** 2026-02-05
+
+---
+
+## Background
+
+The time-tracker currently ingests Claude Code sessions from `~/.claude/projects/`. The user also uses OpenCode, which stores sessions in `~/.local/share/opencode/storage/`. Both tools serve the same purpose (AI coding assistants), so their session data should be unified.
+
+### Data Format Comparison
+
+**Claude Code** (`~/.claude/projects/{project}/{session}.jsonl`):
+- JSONL files with inline messages
+- Each line: `{type: "user"|"assistant"|"summary", timestamp, cwd, message: {content}}`
+- User prompts vs tool results distinguished by content type (string vs array)
+
+**OpenCode** (`~/.local/share/opencode/storage/`):
+- Normalized JSON across directories:
+  - `session/{project_hash}/{session_id}.json` - metadata
+  - `message/{session_id}/{message_id}.json` - message metadata
+  - `part/{message_id}/{part_id}.json` - content
+- All user messages are actual prompts (tool results embedded in assistant parts)
+
+---
+
+## Design
+
+### Data Model
+
+**Rename:** `ClaudeSession` -> `AgentSession`
+
+**New enum:**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionSource {
+    #[default]
+    Claude,
+    OpenCode,
+}
+```
+
+**AgentSession fields:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `session_id` | `String` | Was `claude_session_id` |
+| `source` | `SessionSource` | New field |
+| `parent_session_id` | `Option<String>` | Unchanged |
+| `session_type` | `SessionType` | Unchanged |
+| `project_path` | `String` | Unchanged |
+| `project_name` | `String` | Unchanged |
+| `start_time` | `DateTime<Utc>` | Unchanged |
+| `end_time` | `Option<DateTime<Utc>>` | Unchanged |
+| `message_count` | `i32` | Unchanged |
+| `summary` | `Option<String>` | Claude: summary message. OpenCode: title field |
+| `user_prompts` | `Vec<String>` | Unchanged |
+| `starting_prompt` | `Option<String>` | Unchanged |
+| `assistant_message_count` | `i32` | Unchanged |
+| `tool_call_count` | `i32` | Unchanged |
+| `user_message_timestamps` | `Vec<DateTime<Utc>>` | Unchanged |
+
+**SessionType derivation:**
+- Claude: from session ID pattern (user/agent/subagent)
+- OpenCode: from `parentID` presence (user/subagent only - no background agents)
+
+### Database Schema
+
+**Rename table:** `claude_sessions` -> `agent_sessions`
+
+```sql
+CREATE TABLE agent_sessions (
+    session_id TEXT PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'claude',
+    parent_session_id TEXT,
+    session_type TEXT NOT NULL DEFAULT 'user',
+    project_path TEXT NOT NULL,
+    project_name TEXT NOT NULL,
+    start_time TEXT NOT NULL,
+    end_time TEXT,
+    message_count INTEGER NOT NULL,
+    summary TEXT,
+    user_prompts TEXT DEFAULT '[]',
+    starting_prompt TEXT,
+    assistant_message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0
+);
+
+CREATE INDEX idx_agent_sessions_start_time ON agent_sessions(start_time);
+CREATE INDEX idx_agent_sessions_project_path ON agent_sessions(project_path);
+CREATE INDEX idx_agent_sessions_parent ON agent_sessions(parent_session_id);
+```
+
+Note: `user_message_timestamps` are not persisted in the database — they are
+only used transiently during event generation at indexing time.
+
+**Migration:** Drop and recreate (schema v7). No data migration needed.
+
+### OpenCode Parsing
+
+New module `tt-core/src/opencode.rs`:
+
+1. Scan `~/.local/share/opencode/storage/session/*/` directories
+2. For each `{session_id}.json`:
+   - Parse session metadata (id, directory, title, parentID, time)
+   - List messages from `storage/message/{session_id}/`
+   - For user messages, read parts to extract text content
+   - Count assistant messages and tool parts
+3. Return `Vec<AgentSession>` with `source: OpenCode`
+
+**Performance:** Use rayon for parallel parsing. Lazy part loading - only read parts for user prompt extraction.
+
+### CLI
+
+No changes to CLI interface. `tt ingest sessions` will scan both sources and report combined stats:
+
+```
+Scanning Claude Code sessions...
+Scanning OpenCode sessions...
+Indexed 150 sessions (120 Claude, 30 OpenCode)
+```
+
+### File Changes
+
+| File | Change |
+|------|--------|
+| `tt-core/src/session.rs` | Rename types, add `SessionSource` |
+| `tt-core/src/opencode.rs` | New: OpenCode parser |
+| `tt-core/src/lib.rs` | Export new types |
+| `tt-db/src/lib.rs` | Rename table, add source column, bump schema |
+| `tt-cli/src/commands/ingest.rs` | Call both scanners |
+
+---
+
+## Implementation Tasks
+
+1. Add `SessionSource` enum to `tt-core/src/session.rs`
+2. Rename `ClaudeSession` -> `AgentSession`, add `source` field
+3. Update `tt-db` schema (v6): rename table, add column
+4. Create `tt-core/src/opencode.rs` with OpenCode parser
+5. Update `tt-cli/src/commands/ingest.rs` to scan both sources
+6. Update all references (`claude_session_id` -> `session_id`, etc.)
+7. Run tests and verify with `tt ingest sessions`

--- a/docs/plans/2026-02-06-context-export-parent-session-id.md
+++ b/docs/plans/2026-02-06-context-export-parent-session-id.md
@@ -1,0 +1,229 @@
+# Fix: context export drops parent_session_id from agent sessions
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `parent_session_id` and `session_type` fields to `AgentExport` so `tt context --agents` output includes parent-child session relationships.
+
+**Architecture:** The data already flows correctly through parsing (session.rs) and storage (tt-db). The only gap is the export mapping in `context.rs` — `AgentExport` is missing two fields and `export_agents` doesn't copy them from `AgentSession`.
+
+**Tech Stack:** Rust, serde, chrono
+
+---
+
+### Task 1: Add fields to `AgentExport` struct
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/context.rs:64-79`
+
+**Step 1: Add `parent_session_id` and `session_type` to the struct**
+
+Add two fields after `session_id` in `AgentExport`:
+
+```rust
+/// Agent session information for context export.
+#[derive(Debug, Serialize)]
+pub struct AgentExport {
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    pub session_type: String,
+    pub project_path: String,
+    pub project_name: String,
+    pub start_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starting_prompt: Option<String>,
+    pub user_prompts: Vec<String>,
+    pub user_prompt_count: i32,
+    pub assistant_message_count: i32,
+    pub tool_call_count: i32,
+}
+```
+
+Notes:
+- `parent_session_id` is `Option<String>` with `skip_serializing_if` (only subagents have parents)
+- `session_type` is `String` (serialized from the enum's `as_str()`) — not `Option` since every session has a type
+
+**Step 2: Map the new fields in `export_agents`**
+
+In the `export_agents` function (line 160), add the two fields to the mapping:
+
+```rust
+fn export_agents(
+    db: &Database,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> anyhow::Result<Vec<AgentExport>> {
+    Ok(db
+        .agent_sessions_in_range(start, end)?
+        .into_iter()
+        .map(|s| AgentExport {
+            user_prompt_count: i32::try_from(s.user_prompts.len()).unwrap_or(i32::MAX),
+            session_id: s.session_id,
+            parent_session_id: s.parent_session_id,
+            session_type: s.session_type.as_str().to_string(),
+            project_path: s.project_path,
+            project_name: s.project_name,
+            start_time: s.start_time,
+            end_time: s.end_time,
+            summary: s.summary,
+            starting_prompt: s.starting_prompt,
+            user_prompts: s.user_prompts,
+            assistant_message_count: s.assistant_message_count,
+            tool_call_count: s.tool_call_count,
+        })
+        .collect())
+}
+```
+
+**Step 3: Run `cargo clippy --all-targets` and `cargo fmt --check`**
+
+Run: `cargo clippy --all-targets && cargo fmt --check`
+Expected: No warnings, no format issues
+
+### Task 2: Update existing test and add coverage for new fields
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/context.rs` (test module, line 480+)
+
+**Step 1: Update `test_agent_export_serialization` to cover new fields**
+
+The existing test at line 480 constructs an `AgentExport` without the new fields — it will fail to compile. Update it:
+
+```rust
+#[test]
+fn test_agent_export_serialization() {
+    let agent = AgentExport {
+        session_id: "session-123".to_string(),
+        parent_session_id: None,
+        session_type: "user".to_string(),
+        project_path: "/home/user/project".to_string(),
+        project_name: "project".to_string(),
+        start_time: chrono::DateTime::parse_from_rfc3339("2026-01-15T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
+        end_time: Some(
+            chrono::DateTime::parse_from_rfc3339("2026-01-15T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        summary: Some("Implemented feature X".to_string()),
+        starting_prompt: Some("Implement feature X".to_string()),
+        user_prompts: vec!["Implement feature X".to_string(), "Add tests".to_string()],
+        user_prompt_count: 2,
+        assistant_message_count: 3,
+        tool_call_count: 10,
+    };
+
+    let json = serde_json::to_string(&agent).unwrap();
+    assert!(json.contains("\"session_id\""));
+    assert!(json.contains("\"session_type\""));
+    assert!(json.contains("\"user\""));
+    assert!(json.contains("\"project_path\""));
+    assert!(json.contains("\"user_prompts\""));
+    assert!(json.contains("\"tool_call_count\""));
+    // parent_session_id should be skipped when None
+    assert!(!json.contains("\"parent_session_id\""));
+}
+```
+
+**Step 2: Add test for subagent with parent_session_id**
+
+```rust
+#[test]
+fn test_agent_export_with_parent_session_id() {
+    let agent = AgentExport {
+        session_id: "agent-a913a65".to_string(),
+        parent_session_id: Some("parent-session-123".to_string()),
+        session_type: "subagent".to_string(),
+        project_path: "/home/user/project".to_string(),
+        project_name: "project".to_string(),
+        start_time: chrono::DateTime::parse_from_rfc3339("2026-01-15T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
+        end_time: Some(
+            chrono::DateTime::parse_from_rfc3339("2026-01-15T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        summary: None,
+        starting_prompt: Some("Run tests".to_string()),
+        user_prompts: vec!["Run tests".to_string()],
+        user_prompt_count: 1,
+        assistant_message_count: 2,
+        tool_call_count: 5,
+    };
+
+    let json = serde_json::to_string(&agent).unwrap();
+    assert!(json.contains("\"parent_session_id\""));
+    assert!(json.contains("\"parent-session-123\""));
+    assert!(json.contains("\"session_type\""));
+    assert!(json.contains("\"subagent\""));
+}
+```
+
+**Step 3: Add integration test for export_agents mapping**
+
+Update the existing `test_export_agents_returns_sessions_in_range` (line 897) to also assert new fields, and add a test with a subagent that has a parent:
+
+```rust
+#[test]
+fn test_export_agents_includes_parent_session_id() {
+    let db = tt_db::Database::open_in_memory().unwrap();
+
+    // Insert a subagent session with parent_session_id
+    let session = tt_core::session::AgentSession {
+        session_id: "agent-a913a65".to_string(),
+        source: tt_core::session::SessionSource::default(),
+        parent_session_id: Some("parent-session-123".to_string()),
+        session_type: tt_core::session::SessionType::Subagent,
+        project_path: "/home/user/my-project".to_string(),
+        project_name: "my-project".to_string(),
+        start_time: chrono::DateTime::parse_from_rfc3339("2026-01-15T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
+        end_time: Some(
+            chrono::DateTime::parse_from_rfc3339("2026-01-15T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        message_count: 3,
+        summary: None,
+        user_prompts: vec!["Run tests".to_string()],
+        starting_prompt: Some("Run tests".to_string()),
+        assistant_message_count: 2,
+        tool_call_count: 5,
+        user_message_timestamps: Vec::new(),
+    };
+    db.upsert_agent_session(&session).unwrap();
+
+    let start = chrono::DateTime::parse_from_rfc3339("2026-01-15T09:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let end = chrono::DateTime::parse_from_rfc3339("2026-01-15T13:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let exports = export_agents(&db, start, end).unwrap();
+
+    assert_eq!(exports.len(), 1);
+    let agent = &exports[0];
+    assert_eq!(
+        agent.parent_session_id.as_deref(),
+        Some("parent-session-123")
+    );
+    assert_eq!(agent.session_type, "subagent");
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p tt-cli`
+Expected: All tests pass
+
+**Step 5: Run full checks**
+
+Run: `cargo clippy --all-targets && cargo fmt --check && cargo test`
+Expected: All green


### PR DESCRIPTION
## Summary

Extends session ingestion to support both Claude Code and OpenCode with a unified `AgentSession` model.

**Breaking change (pre-alpha):** Schema bumped to v7. Existing databases must be deleted and re-ingested.

### Changes

- **`tt-core/session.rs`**: Add `SessionSource` enum (`Claude`, `OpenCode`), rename `ClaudeSession` → `AgentSession`, `claude_session_id` → `session_id`
- **`tt-core/opencode.rs`** (new): OpenCode parser — reads `session/`, `message/`, `part/` directory structure, extracts prompts, counts tools, parallel scanning with rayon
- **`tt-db`**: Schema v7 — `agent_sessions` table with `source` column, renamed methods
- **`tt-cli/ingest.rs`**: Scans both `~/.claude/projects/` and `~/.local/share/opencode/storage/`, event source derived from session
- **`tt-cli/context.rs`**: Export types use `session_id` instead of `claude_session_id`

### Design doc

See `docs/plans/2026-02-05-opencode-session-ingestion.md`

## Test plan

- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --all` — 358 tests pass
- [x] `cargo fmt --check` — clean
- [x] New tests: SessionSource round-trip, DB source round-trip (both variants), OpenCode parser (basic, messages, subagent, missing dirs, malformed JSON, end_time edge cases, scanner), event source propagation