### PR TITLE
feat(tt-core): migrate OpenCode ingestion from JSON files to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,5 @@ $RECYCLE.BIN/
 
 .sisyphus/*
 !.sisyphus/rules/
+
+/ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,123 +2,112 @@
 
 AI-native time tracker that passively collects activity signals from development tools and uses LLMs to generate accurate timesheets.
 
-## Quick Commands
-
-```bash
-cargo build                     # Build all crates
-cargo clippy --all-targets      # Lint (should pass with no warnings)
-cargo fmt --check               # Check formatting
-cargo test                      # Run all tests
-cargo run -- --help             # Show CLI help
-cargo deny check                # Check dependencies (licenses, advisories)
-```
-
-## Project Structure
+## Structure
 
 ```
 crates/
-├── tt-cli/     # Main CLI binary (clap-based)
-├── tt-core/    # Domain logic: events, streams, time entries
-├── tt-db/      # SQLite storage layer (rusqlite)
-└── tt-llm/     # Claude API integration
+├── tt-cli/        # CLI binary ("tt"). Clap dispatch, 9 subcommands, anyhow errors
+│   ├── src/
+│   │   ├── main.rs         # Entry point: parse args → open db → dispatch
+│   │   ├── cli.rs          # Clap definitions (Commands, IngestEvent, StreamsAction)
+│   │   ├── config.rs       # Figment config loading (defaults → TOML → env)
+│   │   └── commands/       # One file per subcommand + snapshots/
+│   └── tests/e2e_flow.rs   # Integration tests (spawns actual binary)
+├── tt-core/       # Domain logic. See crates/tt-core/AGENTS.md
+└── tt-db/         # SQLite storage. See crates/tt-db/AGENTS.md
+config/            # tmux-hook.conf (event capture setup)
+scripts/           # deploy-remote.sh (binary → remote ~/.local/bin/tt)
+specs/             # Architecture docs, design specs, research notes
 ```
 
 ### Crate Dependencies
 
 ```
 tt-cli ─┬─> tt-core
-        ├─> tt-db ───> tt-core
-        └─> tt-llm ──> tt-core
+        └─> tt-db ───> tt-core
 ```
 
-## Code Style
+`tt-llm` is referenced in specs but does not exist yet.
+
+## Where to Look
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Add CLI subcommand | `tt-cli/src/cli.rs` + `commands/{name}.rs` + `commands/mod.rs` | Follow existing pattern (see `tag.rs` for simple, `report.rs` for complex) |
+| Change time algorithm | `tt-core/src/allocation.rs` | 1366-line algo with extensive tests. See `tt-core/AGENTS.md` |
+| Add DB table/column | `tt-db/src/lib.rs` | Bump `SCHEMA_VERSION`, add to `init()`. No migrations—schema mismatch = fail-fast |
+| Add event type | `tt-db/src/lib.rs` (`StoredEvent`) | Then handle in `allocation.rs` and relevant command |
+| Session scanning | `tt-core/src/session.rs` (Claude), `tt-core/src/opencode.rs` (OpenCode) | Parse JSONL session files from `~/.claude/` and `~/.local/share/opencode/` |
+| Config options | `tt-cli/src/config.rs` | Figment: defaults → `~/.config/tt/config.toml` → `TT_*` env vars |
+| Snapshot test update | Run `cargo insta review` | 18 snapshots in `tt-cli/src/commands/snapshots/` |
+| Deploy binary | `scripts/deploy-remote.sh` | Builds release, copies via SSH, optionally configures tmux hook |
+
+## Commands
+
+```bash
+cargo build                     # Build all crates
+cargo clippy --all-targets      # Lint (must pass with zero warnings; -D warnings in CI)
+cargo fmt --check               # Format check (max_width=100)
+cargo test                      # Run all tests (unit + integration + snapshots)
+cargo deny check                # Dependency audit (licenses + advisories)
+cargo insta review              # Review snapshot test changes
+cargo run -- --help             # Show CLI help
+```
+
+CI (`.github/workflows/pr-and-main.yml`): lint job (fmt + deny) + build job (clippy + test). Runs on push to main and PRs.
+
+## Code Conventions
 
 ### Error Handling
 
-- **Library crates** (`tt-core`, `tt-db`, `tt-llm`): Use `thiserror` for typed errors
-- **CLI crate** (`tt-cli`): Use `anyhow` for ergonomic error propagation
+- **Library crates** (`tt-core`, `tt-db`): `thiserror` typed errors
+- **CLI crate** (`tt-cli`): `anyhow` with `.context("message")`
 
-```rust
-// In library crates
-#[derive(Debug, thiserror::Error)]
-pub enum DbError {
-    #[error("database not found: {0}")]
-    NotFound(PathBuf),
-    #[error("sqlite error: {0}")]
-    Sqlite(#[from] rusqlite::Error),
-}
+### Lint Suppressions
 
-// In CLI
-fn main() -> anyhow::Result<()> {
-    // Use context() for adding error context
-    let db = Database::open(&path).context("failed to open database")?;
-}
-```
+Use `#[expect(clippy::lint_name, reason = "...")]` — never bare `#[allow]`. Every suppression needs a reason string.
+
+### Workspace Lints (Cargo.toml)
+
+- `unsafe_code = "deny"` — no unsafe anywhere
+- `clippy::all`, `pedantic`, `nursery` = warn
+- Allowed: `module_name_repetitions`, `must_use_candidate`, `missing_errors_doc`, `missing_panics_doc`
 
 ### Async
 
-- Use `tokio` only where needed (HTTP calls in `tt-llm`, file watching)
-- Prefer sync code in `tt-db` (rusqlite is sync)
-- CLI uses `#[tokio::main]` but most operations are sync
+Sync everywhere except future `tt-llm` (which would use tokio for HTTP). CLI has `#[tokio::main]`-ready but currently all sync. `tt-db` is sync (rusqlite).
 
 ### Logging
 
-Use `tracing` macros with structured fields:
+`tracing` with structured fields: `tracing::info!(count = events.len(), "processed")`. CLI `--verbose` flag sets `debug` level.
 
-```rust
-tracing::info!(event_count = events.len(), "processed events");
-tracing::debug!(?event, "received event");
-```
+### Testing Patterns
 
-### Testing
+- **Unit tests**: `#[cfg(test)] mod tests` at bottom of same file
+- **Snapshots**: `insta::assert_snapshot!` for CLI output (report, streams, status)
+- **DB tests**: `Database::open_in_memory()` — no filesystem needed
+- **Fixture builders**: `make_event()`, `make_test_stream()`, `TestEvent::tmux_focus()` — small helpers with sensible defaults
+- **Integration**: `tt-cli/tests/e2e_flow.rs` spawns actual binary via `Command`
+- **Temp dirs**: `tempfile::TempDir` for filesystem isolation
 
-- Use `insta` for snapshot testing CLI output and complex data structures
-- Use `tempfile` for database tests
-- Tests live in the same file as the code they test (`#[cfg(test)]` modules)
+### Configuration
 
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use insta::assert_snapshot;
+Figment layered loading: compiled defaults → `~/.config/tt/config.toml` → `TT_*` env vars. Currently only `database_path` is configurable.
 
-    #[test]
-    fn test_format_output() {
-        let output = format_entries(&entries);
-        assert_snapshot!(output);
-    }
-}
-```
+## Anti-Patterns
+
+- **No migrations**: Schema version mismatch = hard error. DB must be recreated on schema change.
+- **No `unwrap()` in non-test code** (except compile-time-safe patterns like `LazyLock` regex, hardcoded `NaiveTime`)
+- **No `tt-llm` crate yet** — docs reference it but it's unimplemented
 
 ## Key Types
 
-### `tt-core`
-
-- `Event` - Raw activity signal (file save, command run, etc.)
-- `Stream` - Named collection of events from a source
-- `TimeEntry` - Consolidated time entry for reporting
-
-### `tt-db`
-
-- `Database` - SQLite connection wrapper
-- Event and time entry persistence
-
-### `tt-llm`
-
-- `Client` - Claude API client
-- Prompt construction and response parsing
-
-## Configuration
-
-Uses `figment` for layered configuration:
-
-1. Defaults (compiled in)
-2. Config file (`~/.config/tt/config.toml`)
-3. Environment variables (`TT_*`)
-
-## Architecture Notes
-
-- **Event sourcing**: Raw events are immutable, stored in SQLite
-- **Lazy aggregation**: Time entries computed on demand from events
-- **Offline-first**: All data local, LLM calls optional
-- **Pluggable collectors**: Each tool (editor, terminal) has its own event stream
+| Type | Crate | Role |
+|------|-------|------|
+| `StoredEvent` | tt-db | Raw activity signal (file save, pane focus, AFK, agent action) |
+| `Database` | tt-db | SQLite connection wrapper (80+ methods) |
+| `Stream` | tt-db | Coherent unit of work with direct/delegated time |
+| `AllocatableEvent` | tt-core | Trait for events that participate in time allocation |
+| `AllocationConfig` | tt-core | Tunables: attention_window (1min), agent_timeout (30min) |
+| `AgentSession` | tt-core | Parsed Claude/OpenCode session metadata |
+| `Config` | tt-cli | App config (database_path) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "chrono",
  "insta",
  "rayon",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/tt-cli/src/commands/ingest.rs
+++ b/crates/tt-cli/src/commands/ingest.rs
@@ -345,8 +345,8 @@ use tt_db::StoredEvent;
 
 /// Run the sessions index command.
 ///
-/// Scans Claude Code and `OpenCode` session directories and upserts
-/// them into the database.
+/// Scans Claude Code session directories and the `OpenCode` `SQLite`
+/// database, then upserts discovered sessions into the database.
 pub fn index_sessions(db: &tt_db::Database) -> Result<()> {
     let mut all_sessions = Vec::new();
 
@@ -361,11 +361,11 @@ pub fn index_sessions(db: &tt_db::Database) -> Result<()> {
     }
 
     // OpenCode
-    let opencode_dir = get_opencode_storage_dir()?;
-    if opencode_dir.exists() {
+    let opencode_db = get_opencode_db_path()?;
+    if opencode_db.exists() {
         println!("Scanning OpenCode sessions...");
         let opencode_sessions =
-            scan_opencode_sessions(&opencode_dir).context("failed to scan OpenCode sessions")?;
+            scan_opencode_sessions(&opencode_db).context("failed to scan OpenCode sessions")?;
         println!("  Found {} OpenCode sessions", opencode_sessions.len());
         all_sessions.extend(opencode_sessions);
     }
@@ -472,9 +472,9 @@ fn get_claude_projects_dir() -> Result<PathBuf> {
     Ok(home_dir()?.join(".claude").join("projects"))
 }
 
-/// Get the `OpenCode` storage directory path.
-fn get_opencode_storage_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".local/share/opencode/storage"))
+/// Get the `OpenCode` database path.
+fn get_opencode_db_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".local/share/opencode/opencode.db"))
 }
 
 /// Reads all events from the events file in the specified data directory.

--- a/crates/tt-core/AGENTS.md
+++ b/crates/tt-core/AGENTS.md
@@ -1,0 +1,65 @@
+# tt-core — Domain Logic
+
+Core algorithms and types for time tracking. Pure computation + session parsing (file I/O for Claude, SQLite for OpenCode).
+
+## Modules
+
+| Module | Lines | Role |
+|--------|-------|------|
+| `allocation.rs` | 1366 | Time allocation algorithm (direct + delegated) |
+| `session.rs` | 980 | Claude Code session scanning/parsing |
+| `opencode.rs` | ~790 | OpenCode session scanning from SQLite (`opencode.db`) |
+| `project.rs` | ~50 | Git remote → project name extraction |
+
+## Allocation Algorithm (`allocation.rs`)
+
+Computes direct (human focus) and delegated (agent) time per stream.
+
+### Flow
+
+1. Build **focus timeline** from `tmux_pane_focus`, `afk_change`, `tmux_scroll`, `window_focus`, `browser_tab` events
+2. Build **agent activity timeline** from `agent_session` + `agent_tool_use` events
+3. Walk intervals: attribute time based on focus state and agent state
+
+### Key Types
+
+- `AllocatableEvent` — trait that `StoredEvent` (tt-db) implements. Methods: `timestamp()`, `event_type()`, `stream_id()`, `session_id()`, `action()`, `data()`
+- `AllocationConfig` — `attention_window_ms` (default 60s), `agent_timeout_ms` (default 30min)
+- `StreamTime` — result per stream: `time_direct_ms` + `time_delegated_ms`
+- `FocusState` — enum: `Focused { stream_id, focus_start }` | `Unfocused`
+- `AgentSession` — tracks per-session: `first_tool_use_at`, `last_tool_use_at`, `ended`
+
+### Rules
+
+- Focus gaps > `attention_window_ms` are capped (no inflated time from sparse events)
+- AFK with `idle_duration_ms` retroactively subtracts idle time (capped at attention_window)
+- Agent sessions without tool_use events get zero delegated time
+- Agent timeout: no tool_use for `agent_timeout_ms` → session ends at last tool_use
+- `user_message` events reset the attention window (like scroll)
+- Focus hierarchy: terminal uses tmux stream, browser uses browser stream
+
+### Testing
+
+`TestEvent` struct with builder methods: `tmux_focus()`, `afk_change()`, `agent_session()`, `agent_tool_use()`, `user_message()`, `window_focus()`, `browser_tab()`. 30+ test cases cover edge cases (gaps, capping, concurrent agents, AFK retroactive).
+
+## Session Scanning (`session.rs` + `opencode.rs`)
+
+Parses Claude Code (`~/.claude/projects/`) JSONL session files and OpenCode (`~/.local/share/opencode/opencode.db`) SQLite database.
+
+### Key Types
+
+- `AgentSession` — parsed session: `session_id`, `source`, `parent_session_id`, `session_type`, `project_path`, `start_time`, `end_time`, `message_count`, `user_prompts`, etc.
+- `SessionSource` — enum: `Claude` | `OpenCode`
+- `SessionType` — enum: `User` | `Agent` | `Subagent`. In `session.rs` inferred from session_id format; in `opencode.rs` `Subagent` is set when `parent_id` is present.
+
+### Parsing Rules
+
+- `user_prompts`: max 5, each truncated to `MAX_PROMPT_LENGTH` bytes (currently 2000), UTF-8 boundary safe
+- `user_message_timestamps`: max 1000
+- `message_count`, `assistant_message_count`, `tool_call_count` are `i32` and saturate at `i32::MAX`
+- Parent session ID extracted from directory structure (Claude) or session metadata (OpenCode)
+- Empty/whitespace-only user prompts are skipped
+
+## Project Identification (`project.rs`)
+
+`extract_project_name()`: workspace path → project name. Strips known workspace prefixes, falls back to last path component.

--- a/crates/tt-core/Cargo.toml
+++ b/crates/tt-core/Cargo.toml
@@ -13,6 +13,7 @@ serde_json.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
 rayon.workspace = true
+rusqlite.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/tt-core/src/session.rs
+++ b/crates/tt-core/src/session.rs
@@ -125,6 +125,8 @@ pub enum SessionError {
     Io(#[from] std::io::Error),
     #[error("JSON parse error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
     #[error("no messages found in session")]
     NoMessages,
     #[error("no project path found in session")]

--- a/crates/tt-db/AGENTS.md
+++ b/crates/tt-db/AGENTS.md
@@ -1,0 +1,91 @@
+# tt-db — SQLite Storage Layer
+
+Single-file monolith (`src/lib.rs`, 2363 lines). All database types and methods in one file.
+
+## Schema (v7)
+
+No migrations. Version mismatch = `DbError::SchemaVersionMismatch` (hard error). Bump `SCHEMA_VERSION` constant + recreate DB.
+
+### Tables
+
+```sql
+events (id TEXT PK, timestamp TEXT, type TEXT, source TEXT, schema_version INT,
+        cwd TEXT, git_project TEXT, git_workspace TEXT, pane_id TEXT,
+        tmux_session TEXT, window_index INT, status TEXT, idle_duration_ms INT,
+        action TEXT, session_id TEXT, stream_id TEXT FK, assignment_source TEXT)
+
+streams (id TEXT PK, created_at TEXT, updated_at TEXT, name TEXT,
+         time_direct_ms INT, time_delegated_ms INT,
+         first_event_at TEXT, last_event_at TEXT, needs_recompute INT)
+
+stream_tags (stream_id TEXT, tag TEXT, PK(stream_id, tag), FK stream_id)
+
+agent_sessions (session_id TEXT PK, source TEXT, parent_session_id TEXT,
+                session_type TEXT, project_path TEXT, project_name TEXT,
+                start_time TEXT, end_time TEXT, message_count INT,
+                summary TEXT, user_prompts TEXT, starting_prompt TEXT,
+                assistant_message_count INT, tool_call_count INT)
+```
+
+Timestamps: ISO 8601 TEXT (`2024-01-15T10:30:00.000Z`), always UTC, millisecond precision. Lexicographic order = chronological order.
+
+### Indexes
+
+`idx_events_timestamp`, `idx_events_type`, `idx_events_stream`, `idx_events_cwd`, `idx_events_session`, `idx_events_git_project`, `idx_streams_updated`, `idx_stream_tags_tag`, `idx_agent_sessions_start_time`, `idx_agent_sessions_project_path`, `idx_agent_sessions_parent`
+
+## Key Types
+
+- `Database` — wraps `rusqlite::Connection`. `Send` but not `Sync`.
+- `StoredEvent` — implements `tt_core::AllocatableEvent` trait
+- `Stream` — work unit with computed time fields
+- `DbError` — `Sqlite(rusqlite::Error)` | `SchemaVersionMismatch { found, expected }`
+- `SourceStatus` — last event timestamp per source
+
+## Method Reference
+
+### Events
+| Method | Purpose |
+|--------|---------|
+| `insert_event` / `insert_events` | Idempotent insert (`INSERT OR IGNORE`) |
+| `get_events` | All events, optional time_after/time_before filters |
+| `get_events_in_range` | Events between start..end (inclusive) |
+| `get_events_by_stream` | Events for a specific stream |
+| `get_events_without_stream` | Unassigned events |
+| `get_last_event_per_source` | Latest timestamp per source name |
+
+### Streams
+| Method | Purpose |
+|--------|---------|
+| `insert_stream` | Create new stream |
+| `get_stream` / `get_streams` | Retrieve by ID or all |
+| `streams_in_range` | Streams overlapping a time range |
+| `resolve_stream` | Find by ID prefix or name |
+| `assign_event_to_stream` / `assign_events_to_stream` | Set stream_id on events |
+| `clear_inferred_assignments` | Remove auto-assigned stream_ids |
+| `delete_orphaned_streams` | Remove streams with no events |
+| `update_stream_times` | Set direct/delegated ms + event timestamps |
+| `mark_streams_for_recompute` | Flag streams needing time recalculation |
+| `get_streams_needing_recompute` | Streams with needs_recompute=1 |
+
+### Tags
+| Method | Purpose |
+|--------|---------|
+| `add_tag` | Idempotent tag addition |
+| `get_tags` | Tags for a stream |
+| `delete_tag` | Remove tag from stream |
+| `get_all_tags` | All unique tags |
+| `get_streams_with_tags` | Streams + their tags (joined) |
+
+### Agent Sessions
+| Method | Purpose |
+|--------|---------|
+| `upsert_agent_session` | Insert or update session metadata |
+| `agent_sessions_in_range` | Sessions overlapping a time range |
+
+## Thread Safety
+
+`Database` is `Send` (movable between threads) but NOT `Sync` (no shared access). For multi-threaded use: `Mutex<Database>`, connection pool, or separate instances per thread.
+
+## Testing
+
+Use `Database::open_in_memory()` for all tests. Helper: `make_event(id, timestamp, event_type)` returns `StoredEvent` with sensible defaults. 50+ unit tests covering field persistence, idempotency, range queries, cascading deletes, schema version checks.

--- a/docs/plans/2026-02-14-opencode-sqlite-migration.md
+++ b/docs/plans/2026-02-14-opencode-sqlite-migration.md
@@ -1,0 +1,250 @@
+# OpenCode SQLite Migration - Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Update OpenCode session ingestion to read from SQLite database instead of JSON files, matching OpenCode's new storage format.
+
+**Architecture:** Replace filesystem walks + JSON deserialization with rusqlite queries against `~/.local/share/opencode/opencode.db`. The public API changes from `scan_opencode_sessions(storage_dir: &Path)` to `scan_opencode_sessions(db_path: &Path)`. Output type (`AgentSession`) is unchanged. Drop rayon parallelism (single SQLite connection with cached prepared statements is faster than opening thousands of files).
+
+**Tech Stack:** rusqlite (already a workspace dependency, `bundled` feature includes JSON1 extension — `json_extract()` works out of the box)
+
+---
+
+## Context
+
+OpenCode migrated from normalized JSON files (`storage/session/`, `storage/message/`, `storage/part/`) to a single SQLite database. The schema:
+
+- `session`: `id`, `directory`, `title` (NOT NULL), `parent_id`, `time_created` (ms), `time_updated` (ms)
+- `message`: `id`, `session_id`, `time_created` (ms), `data` (JSON with `role` field)
+- `part`: `id`, `message_id`, `session_id`, `time_created` (ms), `data` (JSON with `type` + optional `text`)
+
+Part types we care about: `text` (for user prompts), `tool` (for tool call count). Others (`step-finish`, `step-start`, `reasoning`, `agent`, `compaction`, `file`, `patch`) ignored.
+
+## Review Notes
+
+**Performance:** Per-session querying (3K sessions × message query + tool count query + part queries for user messages only) against a 6.3GB db. With `prepare_cached` and indexes on `message(session_id)` and `part(session_id)`, each query is an indexed lookup. Tool count uses a single `SELECT COUNT(*) ... WHERE session_id = ?1` per session rather than per-message queries. Start with this approach; if too slow, refactor to 3-4 bulk queries + HashMap aggregation in Rust.
+
+**Correctness:**
+- `json_extract()` returns SQL NULL for missing keys — all extracted values must be handled as `Option<String>` on the Rust side
+- Tool count uses one per-session query: `SELECT COUNT(*) FROM part WHERE session_id = ?1 AND json_extract(data, '$.type') = 'tool'`
+- `session.title` is NOT NULL but can be empty string — map empty → `None` for summary
+
+**Robustness:**
+- If the db file exists but has no `session` table (schema drift / corrupt db), the `prepare()` call will fail. Catch this as a `SessionError::Database` and return empty `Vec` with a warning, rather than propagating the error up. This matches the current graceful behavior for `scan_nonexistent_dir`.
+- OpenCode uses WAL journal mode. Read-only + `SQLITE_OPEN_NO_MUTEX` is safe for concurrent reads.
+
+**API change:** `parse_opencode_session()` is currently `pub`. Removing it is a breaking change to `tt-core`'s public API. Nothing outside the crate uses it (only `ingest.rs` uses `scan_opencode_sessions`), so this is fine — but the new `build_agent_session` should be private.
+
+---
+
+### Task 1: Add rusqlite dependency + SessionError variant
+
+**Files:**
+- Modify: `crates/tt-core/Cargo.toml`
+- Modify: `crates/tt-core/src/session.rs` (SessionError enum, ~line 122)
+
+**Step 1: Add rusqlite to tt-core dependencies**
+
+In `crates/tt-core/Cargo.toml`, add to `[dependencies]`:
+```toml
+rusqlite.workspace = true
+```
+
+**Step 2: Add Database error variant to SessionError**
+
+In `crates/tt-core/src/session.rs`, add to the `SessionError` enum:
+```rust
+#[error("database error: {0}")]
+Database(#[from] rusqlite::Error),
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cargo check -p tt-core`
+Expected: compiles with no errors
+
+**Step 4: Commit**
+
+```
+feat(tt-core): add rusqlite dependency for OpenCode SQLite ingestion
+```
+
+---
+
+### Task 2: Rewrite opencode.rs implementation + tests
+
+**Files:**
+- Rewrite: `crates/tt-core/src/opencode.rs` (entire file — implementation and tests together as one atomic change)
+
+#### Implementation
+
+**Remove:**
+- `OpenCodeSession`, `OpenCodeTime`, `OpenCodeMessage`, `OpenCodeMessageTime`, `OpenCodePart` structs
+- `MessageRole`, `PartType` enums
+- `read_json_files()` helper
+- `parse_opencode_session()` public function
+
+**Keep:**
+- `unix_ms_to_datetime()` helper (still needed for timestamp conversion)
+
+**Add:**
+- `SessionRow` struct (maps to SQLite session table columns: `id`, `directory`, `title`, `parent_id`, `time_created`, `time_updated`)
+- `scan_opencode_sessions(db_path: &Path)` — opens read-only connection, queries all sessions, calls `build_agent_session` per session. On db open failure or missing `session` table, log a warning and return `Ok(Vec::new())`.
+- `build_agent_session(conn, session_row)` — private fn, queries messages + parts for one session, aggregates into `AgentSession`
+
+**SQL queries (4 prepared statements):**
+
+```sql
+-- 1. All sessions (run once, not cached)
+SELECT id, directory, title, parent_id, time_created, time_updated FROM session
+
+-- 2. Messages for a session (cached, role extracted from JSON data column)
+SELECT id, time_created, json_extract(data, '$.role') as role
+FROM message WHERE session_id = ?1 ORDER BY time_created
+
+-- 3. Text parts for a user message (cached, for prompt extraction)
+SELECT json_extract(data, '$.text') as text
+FROM part WHERE message_id = ?1 AND json_extract(data, '$.type') = 'text'
+ORDER BY id
+
+-- 4. Tool count for a session (cached, one query instead of per-message)
+SELECT COUNT(*) FROM part
+WHERE session_id = ?1 AND json_extract(data, '$.type') = 'tool'
+```
+
+**Key implementation details:**
+- Open with `OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX`
+- Set `busy_timeout(Duration::from_secs(5))` for concurrent access with running OpenCode
+- Use `prepare_cached` for queries 2, 3, 4 (reused per-session)
+- Map empty `session.title` to `None` for `summary` field
+- `time_updated` is NOT NULL in SQLite (unlike old JSON where it was Optional), simplify end_time calc
+- All `json_extract()` results handled as `Option<String>` (returns NULL for missing keys)
+
+**Message processing loop** (structurally identical to current code):
+- Iterate messages sorted by `time_created`
+- For user messages: query text parts (query 3), concatenate, apply `truncate_prompt`, collect timestamps
+- For assistant messages: just count them (tool count comes from query 4, done once per session)
+- Same limits: `MAX_USER_PROMPTS`, `MAX_USER_MESSAGE_TIMESTAMPS`, saturating arithmetic
+
+#### Tests
+
+**SQLite test helpers** (replace JSON fixture helpers):
+
+```rust
+fn create_test_db() -> (TempDir, PathBuf)
+// Creates temp dir with opencode.db containing schema:
+//   session(id, directory, title, parent_id, time_created, time_updated)
+//   message(id, session_id, time_created, time_updated, data)
+//   part(id, message_id, session_id, time_created, time_updated, data)
+// Plus indexes on message(session_id), part(message_id), part(session_id)
+// Returns (TempDir, db_path) — TempDir kept alive for RAII cleanup
+// Connection closed so scan_opencode_sessions can open it
+
+fn insert_session(db_path, id, directory, title, parent_id, created_ms, updated_ms)
+fn insert_message(db_path, id, session_id, role, created_ms)
+fn insert_part(db_path, id, message_id, session_id, part_type, text, created_ms)
+// Each opens a brief connection, inserts, closes
+```
+
+**Tests to port** (1:1 from existing, same assertions, different fixture creation):
+
+| # | Old name | New name | Notes |
+|---|----------|----------|-------|
+| 1 | `test_parse_basic_session` | `test_basic_session` | |
+| 2 | `test_parse_session_with_messages` | `test_session_with_messages` | |
+| 3 | `test_parse_subagent_session` | `test_subagent_session` | |
+| 4 | `test_parse_session_missing_messages_dir` | `test_session_with_no_messages` | Session in db, no messages inserted |
+| 5 | `test_scan_opencode_sessions` | `test_scan_multiple_sessions` | |
+| 6 | `test_scan_nonexistent_dir` | `test_scan_nonexistent_db` | Path to non-existent file |
+| 7 | `test_user_prompts_limited` | keep | |
+| 8 | `test_parse_session_with_invalid_timestamp` | `test_invalid_timestamp` | |
+| 9 | `test_end_time_none_when_equal_to_start_time` | keep | |
+| 10 | `test_end_time_from_last_message_beats_updated` | keep | |
+| 11 | `test_parse_session_malformed_json_file` | `test_malformed_message_data` | Insert message with `data = 'not json'`. `json_extract` returns NULL → role is None → message skipped. Verify session parses with 0 messages. |
+| 12 | `test_scan_skips_malformed_sessions` | keep | Session with empty id + valid session in same db |
+| 13 | `test_parse_session_with_messages_verifies_end_time` | keep | |
+| 14 | `test_end_time_none_when_updated_before_created` | keep | |
+| 15 | `test_empty_session_id_rejected` | keep | |
+
+**Drop:**
+- `test_parse_session_missing_required_fields` (SQLite schema enforces NOT NULL)
+
+**Add:**
+- `test_scan_corrupt_db` — db file exists but has no tables (empty file). Returns empty vec with warning, not error.
+
+**Step 1:** Write implementation + tests (entire opencode.rs rewrite)
+
+**Step 2:** Run tests: `cargo test -p tt-core -- opencode` → all pass
+
+**Step 3:** Run clippy: `cargo clippy -p tt-core --all-targets` → no warnings
+
+**Step 4: Commit**
+
+```
+feat(tt-core): migrate OpenCode ingestion from JSON files to SQLite
+
+OpenCode now stores sessions in ~/.local/share/opencode/opencode.db
+instead of JSON files. Update scan_opencode_sessions() to query the
+SQLite database directly using rusqlite.
+```
+
+---
+
+### Task 3: Update CLI path in ingest.rs
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/ingest.rs` (~lines 364-371, 476-478)
+
+**Step 1: Rename and update the path function**
+
+```rust
+// Old:
+fn get_opencode_storage_dir() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".local/share/opencode/storage"))
+}
+
+// New:
+fn get_opencode_db_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".local/share/opencode/opencode.db"))
+}
+```
+
+**Step 2: Update the call site in index_sessions()**
+
+```rust
+// Old:
+let opencode_dir = get_opencode_storage_dir()?;
+if opencode_dir.exists() {
+    let opencode_sessions = scan_opencode_sessions(&opencode_dir)...
+
+// New:
+let opencode_db = get_opencode_db_path()?;
+if opencode_db.exists() {
+    let opencode_sessions = scan_opencode_sessions(&opencode_db)...
+```
+
+**Step 3: Run full test suite**
+
+Run: `cargo test`
+Expected: all tests pass
+
+**Step 4: Run clippy**
+
+Run: `cargo clippy --all-targets`
+Expected: no warnings
+
+**Step 5: Commit**
+
+```
+chore(tt-cli): update OpenCode path from storage dir to SQLite db
+```
+
+---
+
+### Task 4: Update AGENTS.md documentation
+
+**Files:**
+- Modify: `crates/tt-core/AGENTS.md` (Session Scanning section)
+- Modify: `docs/plans/2026-02-05-opencode-session-ingestion.md` (add migration note)
+
+Update references from JSON storage to SQLite. Note that `parse_opencode_session()` no longer exists as a public function and `scan_opencode_sessions` now takes a db path instead of a storage directory.


### PR DESCRIPTION
## Summary

OpenCode recently changed its storage format from JSON files (`~/.local/share/opencode/storage/`) to a SQLite database (`~/.local/share/opencode/opencode.db`). This PR updates the session ingestion logic accordingly.

### Changes

- **`tt-core/src/opencode.rs`** — Complete rewrite: reads from SQLite via `json_extract()` queries instead of walking JSON files. Uses `prepare_cached` for per-session queries, read-only connection with busy timeout for safe concurrent access.
- **`tt-core/Cargo.toml`** — Added `rusqlite.workspace = true`
- **`tt-core/src/session.rs`** — Added `SessionError::Database` variant
- **`tt-cli/src/commands/ingest.rs`** — Updated path from `storage/` dir to `opencode.db`
- **`tt-core/AGENTS.md`** — Updated documentation

### Key design decisions

- **Read-only + `SQLITE_OPEN_NO_MUTEX`** — Safe for concurrent reads while OpenCode is running
- **`json_valid()` guards** in SQL queries — Gracefully handles malformed JSON data columns
- **Graceful degradation** — Missing/corrupt db returns empty vec with warning (matches prior behavior for missing dirs)
- **Per-session tool count** — Single `SELECT COUNT(*)` per session instead of per-message part queries

### Testing

- 16 tests ported from JSON fixtures to SQLite fixtures (same assertions)
- Added `test_scan_corrupt_db` and `test_malformed_message_data` edge cases
- All 299 tests pass across all crates, clippy clean

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a local CLI tool, not a deployed service.