### PR TITLE
fix(daily-standup): enforce tt report as sole source of time data

### DIFF
--- a/.opencode/skills/daily-standup/SKILL.md
+++ b/.opencode/skills/daily-standup/SKILL.md
@@ -24,13 +24,14 @@ digraph standup {
   start [label="1. Parse date\n(convert to ISO 8601 UTC)" shape=ellipse];
   ingest [label="2. Run ingestion\ntt ingest sessions"];
   gather [label="3. Gather context\ntt classify --json"];
-  analyze [label="4. Invoke infer-streams\n(Skill tool, NOT subagent)"];
-  prs [label="5. Look up PRs\n(gh search prs)"];
-  draft [label="6. Draft update\n(logical projects, PR links)"];
-  confirm [label="7. Confirm channel\nwith user"];
-  post [label="8. Post to Slack"];
+  analyze [label="4. Create streams\n(infer-streams skill)"];
+  compute [label="5. Get computed time\ntt report --last-day" style=bold];
+  prs [label="6. Look up PRs\n(gh search prs)"];
+  draft [label="7. Draft update\n(logical projects, PR links)"];
+  confirm [label="8. Confirm channel\nwith user"];
+  post [label="9. Post to Slack"];
 
-  start -> ingest -> gather -> analyze -> prs -> draft -> confirm -> post;
+  start -> ingest -> gather -> analyze -> compute -> prs -> draft -> confirm -> post;
 }
 ```
 
@@ -80,22 +81,37 @@ This outputs JSON with:
 - `sessions[]`: Agent sessions with `session_id`, `project_name`, `summary`, `tool_call_count`, `start_time`, `end_time`
 - `event_clusters[]`: Non-session activity grouped by CWD + time
 
-## Phase 4: Analyze Streams
+## Phase 4: Create Streams
 
-**REQUIRED: Invoke the `infer-streams` skill** to analyze the `tt classify` output. Do NOT try to analyze streams yourself or launch a subagent — use the Skill tool:
+**REQUIRED: Invoke the `infer-streams` skill** and follow its full workflow. Do NOT launch a subagent — use the Skill tool:
 
 ```
 Skill("infer-streams")
 ```
 
-The infer-streams skill handles:
-- Grouping sessions into projects and streams
-- Calculating direct vs delegated time
-- Handling subdirectory merging, null end_times, etc.
+You MUST execute the infer-streams workflow end-to-end:
+1. Group sessions into streams (project + task name)
+2. Build the `tt classify --apply` JSON with `assign_by_session` entries
+3. Run `tt classify --apply assignments.json` — this persists streams AND runs `tt recompute`
 
-Use its output (the time breakdown table and stream details) as the data source for drafting the standup.
+**Do NOT skip this step.** Even for a daily standup, you must create and apply stream assignments. The allocation algorithm is the only source of truth for time — it accounts for attention windows, AFK detection, overlapping sessions, and agent timeouts that are invisible in raw session metadata.
 
-## Phase 5: Look Up PRs
+## Phase 5: Get Computed Time
+
+**MANDATORY GATE: No time numbers without this step.**
+
+```bash
+tt report --last-day --json    # For yesterday
+tt report --day --json         # For today
+```
+
+This is the ONLY acceptable source of time data for the standup. The JSON output contains per-tag breakdowns with exact `time_direct_ms` and `time_delegated_ms` values.
+
+**DO NOT estimate, guess, or mentally compute times from session metadata.** Fields like `duration_minutes` and `tool_call_count` do not account for the allocation algorithm's attention windows, AFK gaps, or overlapping parallel sessions. They will be wrong — typically by 2x or more.
+
+Convert the millisecond values to hours/minutes for the report. Use these exact numbers.
+
+## Phase 6: Look Up PRs
 
 **CRITICAL: Always look up open and recently merged PRs to link in the report.** A standup without PR links is incomplete — readers want to see the artifacts.
 
@@ -109,7 +125,7 @@ gh search prs --author=@me --merged --sort=updated --limit=20
 
 Match PRs to streams by repo name and title. Every accomplishment that produced or advanced a PR should link to it using markdown: `[PR #123](url)`.
 
-## Phase 6: Draft Update
+## Phase 7: Draft Update
 
 **Format: YTH (Yesterday, Today, Hopes/Blockers)**
 
@@ -129,7 +145,7 @@ Write for readers who have no context about your projects.
 
 ### Include PR Links
 
-Every accomplishment that produced or advanced a PR should include a markdown link: `[PR #123](url)`. Use the PRs gathered in Phase 5.
+Every accomplishment that produced or advanced a PR should include a markdown link: `[PR #123](url)`. Use the PRs gathered in Phase 6.
 
 ### Template
 
@@ -138,14 +154,14 @@ Every accomplishment that produced or advanced a PR should include a markdown li
 
 ### Yesterday ({Date})
 
-- **{Logical Project}** — {time estimate}
+- **{Logical Project}** — {direct}h direct | {delegated}h delegated
   - {Accomplishment} — [PR #N](url) (merged/open)
   - {Another accomplishment}
 
-- **{Logical Project}** — {time estimate}
+- **{Logical Project}** — {direct} direct | {delegated} delegated
   - {Accomplishment} — [PR #N](url)
 
-**Totals:** ~{X} hrs direct | ~{Y} hrs delegated
+**Totals:** {X}h direct | {Y}h delegated
 
 {Optional: Brief note about slowdowns or context}
 
@@ -163,10 +179,10 @@ Every accomplishment that produced or advanced a PR should include a markdown li
 - Project names should be recognizable (use repo names or common abbreviations)
 - Accomplishments should be specific enough that someone unfamiliar can understand impact
 - Avoid jargon like "refactoring" without saying what/why
-- Time estimates are approximate—don't overthink precision
+- Time numbers come from `tt report` — copy them exactly, do not round or estimate
 - Delegated time can be very high with parallel agents (10+ hours is normal for heavy days)
 
-## Phase 7: Ask for "Today" Plans
+## Phase 8: Ask for "Today" Plans
 
 The time-tracker data only shows past activity. Ask the user:
 - "What are your plans for today?"
@@ -174,7 +190,7 @@ The time-tracker data only shows past activity. Ask the user:
 
 If user provided plans in the invocation, use those. Otherwise, infer reasonable continuations from yesterday's work (e.g., "continue X" or "open PR for Y").
 
-## Phase 8: Confirm Before Posting
+## Phase 9: Confirm Before Posting
 
 Show the drafted message and confirm:
 - Target channel is correct
@@ -182,7 +198,7 @@ Show the drafted message and confirm:
 
 Use AskUserQuestion if channel wasn't provided or to confirm before posting.
 
-## Phase 9: Post to Slack
+## Phase 10: Post to Slack
 
 Use `mcp__slack__conversations_add_message`:
 - `channel_id`: Use `#channel-name` format
@@ -208,7 +224,9 @@ If posting fails:
 |---------|-----|
 | Skipping ingestion | **Always** run `tt ingest sessions` before `tt classify`. Without it you miss most data. |
 | Skipping remote sync | **Always** check `tt machines` and sync all remotes. Remote events are often 50%+ of total data. |
-| Reporting partial/incomplete numbers | Run the FULL pipeline (ingest → sync → classify → report) before showing any report. Don't stop partway and present incomplete numbers. |
+| Reporting partial/incomplete numbers | Run the FULL pipeline (ingest → sync → classify → assign → report) before showing any report. Don't stop partway and present incomplete numbers. |
+| Guessing time from session metadata | **Never.** `duration_minutes` and `tool_call_count` don't account for attention windows, AFK, or overlapping sessions. Always use `tt report` output. Guesses are typically off by 2x+. |
+| Skipping stream creation | You MUST create streams via `tt classify --apply` before running `tt report`. Without streams, the report has no data. |
 | Reporting by repo directory | Organize by logical project, not filesystem path. `dotfiles` is never a project. Ask the user. |
 | No PR links | Always run `gh search prs` and link every PR mentioned in the report. |
 | Date format error | Use ISO 8601: `2026-02-02T08:00:00Z` or relative like "1 day ago" |


### PR DESCRIPTION
## Problem

The daily-standup skill said to use infer-streams output "as the data source" but didn't specify *which* output or require running `tt report`. This left a gap that allowed guessing time estimates from raw session metadata (`duration_minutes`, `tool_call_count`), which are unscoped and don't account for the allocation algorithm's attention windows, AFK detection, or overlapping sessions. In practice this produced estimates off by ~2x in both directions.

## Changes

- **New Phase 5: Get Computed Time** — mandatory gate requiring `tt report --last-day --json` before drafting; explicitly forbids estimating from session metadata
- **Rename Phase 4 to "Create Streams"** — makes clear this phase must produce a persisted `tt classify --apply` result, not just analysis
- **Explicit 3-step checklist in Phase 4** — group → build JSON → `classify --apply`
- **Template cleanup** — removed `~` approximation markers and "Time estimates are approximate" guideline; replaced with "copy from `tt report` exactly"
- **Two new Common Mistakes rows** — "Guessing time from session metadata" and "Skipping stream creation"
- **Pipeline description updated** — now reads `ingest → sync → classify → assign → report`

## Root Cause

Discovered during a live standup run where the first draft used guessed numbers (6-7h direct, ~106h delegated) vs. the computed reality (13h 44m direct, 48h delegated). The revised workflow with the Phase 5 gate produced the correct numbers.