### PR TITLE
ci: add release workflow with conventional commits versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  version:
+    name: Determine Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      should_release: ${{ steps.bump.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        run: |
+          # Find the latest version tag
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            # No tags yet — first release uses current Cargo.toml version
+            VERSION=$(sed -n '/^\[workspace\.package\]/,/^\[/ s/^version = "\(.*\)"/\1/p' Cargo.toml)
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "First release: v$VERSION"
+            exit 0
+          fi
+
+          # Get commits since last tag
+          COMMITS=$(git log "${LATEST_TAG}..HEAD" --format='%s')
+
+          if [ -z "$COMMITS" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "No commits since $LATEST_TAG"
+            exit 0
+          fi
+
+          # Classify conventional commits
+          MAJOR=false
+          MINOR=false
+          PATCH=false
+
+          while IFS= read -r msg; do
+            # BREAKING: feat!:, fix(scope)!:, or body contains BREAKING CHANGE
+            if echo "$msg" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$msg" | grep -q 'BREAKING CHANGE'; then
+              MAJOR=true
+            elif echo "$msg" | grep -qE '^feat(\(.+\))?:'; then
+              MINOR=true
+            elif echo "$msg" | grep -qE '^fix(\(.+\))?:'; then
+              PATCH=true
+            fi
+          done <<< "$COMMITS"
+
+          if ! $MAJOR && ! $MINOR && ! $PATCH; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "No version-bumping commits since $LATEST_TAG"
+            exit 0
+          fi
+
+          # Parse version from last tag
+          CURRENT="${LATEST_TAG#v}"
+          IFS='.' read -r major minor patch <<< "$CURRENT"
+
+          if $MAJOR; then
+            major=$((major + 1)); minor=0; patch=0
+          elif $MINOR; then
+            minor=$((minor + 1)); patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
+          VERSION="${major}.${minor}.${patch}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "Bumping $CURRENT → $VERSION"
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: version
+    if: needs.version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            use_cross: false
+          - target: aarch64-unknown-linux-gnu
+            use_cross: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross
+        uses: taiki-e/install-action@cross
+
+      - name: Set release version
+        run: sed -i 's/^version = ".*"/version = "${{ needs.version.outputs.version }}"/' Cargo.toml
+
+      - name: Build
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package
+        run: tar czf tt-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release tt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tt-${{ matrix.target }}
+          path: tt-${{ matrix.target }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Bump version in repo
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          sed -i 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
+          cargo update --workspace
+
+      - name: Commit and tag
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: release v${VERSION} [skip ci]"
+          git tag "v${VERSION}"
+          git push origin main --tags
+
+      - uses: actions/download-artifact@v4
+
+      - name: Generate checksums
+        run: |
+          cd tt-x86_64-unknown-linux-gnu
+          sha256sum tt-x86_64-unknown-linux-gnu.tar.gz >> ../SHA256SUMS
+          cd ../tt-aarch64-unknown-linux-gnu
+          sha256sum tt-aarch64-unknown-linux-gnu.tar.gz >> ../SHA256SUMS
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            tt-*/tt-*.tar.gz \
+            SHA256SUMS


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically creates releases on pushes to main
- Parses conventional commit messages (`feat:` → minor, `fix:` → patch, `!:`/`BREAKING CHANGE` → major) to determine the next semver version
- Builds Linux binaries for x86_64 (native) and aarch64 (via `cross`)
- Commits version bump to `Cargo.toml`, creates a git tag, and publishes a GitHub Release with tarballs + SHA256 checksums
- Skips entirely when no version-bumping commits are found (e.g. only `chore:`, `docs:`, `ci:`)
- First release (no existing tags) uses the current workspace version (0.1.0)

## Notes

The release job pushes a version bump commit and tag to `main`. This requires `github-actions[bot]` to have push access — if branch protection is enabled, it needs a bypass rule.