### PR TITLE
fix(ci): skip version commit when Cargo.toml unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
-          git commit -m "chore: release v${VERSION} [skip ci]"
+          git diff --staged --quiet || git commit -m "chore: release v${VERSION} [skip ci]"
           git tag "v${VERSION}"
           git push origin main --tags
 


### PR DESCRIPTION
## Summary

- First release version (0.1.0) already matches Cargo.toml, so the sed is a no-op
- `git commit` fails with "nothing to commit" — blocks tag creation and release
- Fix: `git diff --staged --quiet || git commit ...` skips the commit when there are no changes, while still creating the tag and pushing