### PR TITLE
fix(sync): stream SSH, incremental OpenCode export, gzip compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +330,16 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -529,6 +554,16 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -799,6 +834,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1031,7 @@ dependencies = [
  "clap",
  "dirs",
  "figment",
+ "flate2",
  "fs2",
  "hostname",
  "iana-time-zone",

--- a/crates/tt-cli/Cargo.toml
+++ b/crates/tt-cli/Cargo.toml
@@ -25,6 +25,7 @@ chrono.workspace = true
 figment.workspace = true
 iana-time-zone = "0.1"
 dirs.workspace = true
+flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 fs2 = "0.4"
 regex = "1.11"
 uuid.workspace = true

--- a/crates/tt-cli/src/cli.rs
+++ b/crates/tt-cli/src/cli.rs
@@ -43,6 +43,10 @@ pub enum Commands {
         /// Only export events after this event ID (for incremental sync).
         #[arg(long)]
         after: Option<String>,
+
+        /// Only export events after this timestamp (for incremental `OpenCode` export).
+        #[arg(long)]
+        since: Option<String>,
     },
 
     /// Import events from stdin into local `SQLite` database.

--- a/crates/tt-cli/src/commands/export.rs
+++ b/crates/tt-cli/src/commands/export.rs
@@ -235,16 +235,28 @@ fn default_claude_dir() -> PathBuf {
 }
 
 fn default_opencode_db_path() -> PathBuf {
-    dirs::home_dir()
+    dirs::data_dir()
         .unwrap_or_else(|| PathBuf::from("."))
-        .join(".local/share/opencode/opencode.db")
+        .join("opencode/opencode.db")
 }
 
 /// Runs the export command, outputting all events to stdout.
-pub fn run(after: Option<&str>) -> Result<()> {
+pub fn run(after: Option<&str>, since: Option<&str>) -> Result<()> {
     let identity = crate::machine::require_machine_identity()?;
     let data_dir = default_data_dir();
     let state_dir = crate::config::dirs_state_path().unwrap_or_else(|| data_dir.clone());
+
+    // Parse since timestamp if provided
+    let since_dt = if let Some(since_str) = since {
+        Some(
+            chrono::DateTime::parse_from_rfc3339(since_str)
+                .map_err(|e| anyhow::anyhow!("invalid --since timestamp '{since_str}': {e}"))?
+                .with_timezone(&chrono::Utc),
+        )
+    } else {
+        None
+    };
+
     run_impl(
         &data_dir,
         &default_claude_dir(),
@@ -252,11 +264,16 @@ pub fn run(after: Option<&str>) -> Result<()> {
         Some(&default_opencode_db_path()),
         &identity.machine_id,
         after,
+        since_dt.as_ref(),
         &mut std::io::stdout(),
     )
 }
 
 /// Implementation of export that allows injecting paths for testing.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "export entrypoint parameters are explicit by design"
+)]
 fn run_impl(
     data_dir: &Path,
     claude_dir: &Path,
@@ -264,6 +281,7 @@ fn run_impl(
     opencode_db: Option<&Path>,
     machine_id: &str,
     after: Option<&str>,
+    since: Option<&chrono::DateTime<chrono::Utc>>,
     output: &mut dyn Write,
 ) -> Result<()> {
     // Export tmux events
@@ -280,7 +298,7 @@ fn run_impl(
 
     if let Some(oc_db) = opencode_db {
         if oc_db.exists() {
-            export_opencode_events(oc_db, machine_id, output)?;
+            export_opencode_events(oc_db, machine_id, since, output)?;
         }
     }
 
@@ -290,6 +308,10 @@ fn run_impl(
 /// Exports tmux events from events.jsonl, passing through valid lines.
 /// When `after` is provided, exports events strictly after the matching event
 /// (the marker event itself is excluded).
+///
+/// If the marker event is not found in the file (e.g., after file rotation),
+/// falls back to exporting ALL events. The import side uses `INSERT OR IGNORE`
+/// to handle duplicates, so this is safe.
 fn export_tmux_events(
     events_file: &Path,
     after: Option<&str>,
@@ -298,6 +320,9 @@ fn export_tmux_events(
     let file = File::open(events_file).context("failed to open events.jsonl")?;
     let reader = BufReader::new(file);
     let mut past_marker = after.is_none();
+
+    // Collect lines so we can fall back to exporting all if marker not found.
+    let mut buffered_lines: Vec<String> = Vec::new();
 
     for (line_num, line) in reader.lines().enumerate() {
         let line = match line {
@@ -323,6 +348,10 @@ fn export_tmux_events(
                     }
                 }
             }
+            if !past_marker {
+                // Buffer lines in case we need to fall back to full export.
+                buffered_lines.push(line);
+            }
             // Skip the marker event itself and everything before it
             continue;
         }
@@ -334,6 +363,20 @@ fn export_tmux_events(
             }
             Err(e) => {
                 tracing::warn!(line = line_num + 1, error = %e, "malformed JSON, skipping");
+            }
+        }
+    }
+
+    // If marker was requested but never found (e.g., file was rotated),
+    // export ALL buffered events. INSERT OR IGNORE on the import side
+    // ensures duplicates are harmless.
+    if after.is_some() && !past_marker {
+        tracing::info!(
+            "marker event not found in events.jsonl (file may have rotated); exporting all events"
+        );
+        for line in &buffered_lines {
+            if serde_json::from_str::<&serde_json::value::RawValue>(line).is_ok() {
+                writeln!(output, "{line}").context("failed to write event")?;
             }
         }
     }
@@ -480,14 +523,16 @@ fn export_claude_events(
 fn export_opencode_events(
     opencode_db: &Path,
     machine_id: &str,
+    since: Option<&chrono::DateTime<chrono::Utc>>,
     output: &mut dyn Write,
 ) -> Result<()> {
-    let sessions = tt_core::opencode::scan_opencode_sessions(opencode_db).with_context(|| {
-        format!(
-            "failed to scan OpenCode sessions from {}",
-            opencode_db.display()
-        )
-    })?;
+    let sessions = tt_core::opencode::scan_opencode_sessions(opencode_db, since.copied())
+        .with_context(|| {
+            format!(
+                "failed to scan OpenCode sessions from {}",
+                opencode_db.display()
+            )
+        })?;
 
     for session in sessions {
         let start_ts = session
@@ -1031,6 +1076,7 @@ mod tests {
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         );
 
@@ -1053,6 +1099,7 @@ mod tests {
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1081,6 +1128,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1106,6 +1154,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1137,6 +1186,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1185,6 +1235,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1228,6 +1279,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1265,6 +1317,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1299,6 +1352,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1338,6 +1392,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1371,6 +1426,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1400,6 +1456,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1460,6 +1517,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output1,
         )
         .unwrap();
@@ -1471,6 +1529,7 @@ not valid json
             &data_dir2,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output2,
         )
@@ -1506,6 +1565,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1528,6 +1588,7 @@ not valid json
             &data_dir,
             Some(opencode_db.as_path()),
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1597,6 +1658,7 @@ not valid json
             &data_dir,
             Some(opencode_db.as_path()),
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1703,6 +1765,7 @@ not valid json
             Some(opencode_db1.as_path()),
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output1,
         )
         .unwrap();
@@ -1714,6 +1777,7 @@ not valid json
             &data_dir2,
             Some(opencode_db2.as_path()),
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output2,
         )
@@ -1771,6 +1835,7 @@ not valid json
             Some(opencode_db.as_path()),
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1803,6 +1868,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1885,6 +1951,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         )
         .unwrap();
@@ -1924,6 +1991,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -1970,6 +2038,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output1,
         )
         .unwrap();
@@ -1989,6 +2058,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output2,
         )
@@ -2043,6 +2113,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output,
         );
         assert!(
@@ -2076,6 +2147,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output1,
         )
         .unwrap();
@@ -2105,6 +2177,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output2,
         )
@@ -2143,6 +2216,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output1,
         )
         .unwrap();
@@ -2164,6 +2238,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output2,
         )
@@ -2202,6 +2277,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output1,
         )
         .unwrap();
@@ -2233,6 +2309,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output2,
         )
@@ -2272,6 +2349,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             None,
+            None,
             &mut output1,
         )
         .unwrap();
@@ -2284,6 +2362,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output2,
         )
@@ -2311,6 +2390,7 @@ not valid json
             &data_dir,
             None,
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         );
@@ -2389,6 +2469,7 @@ not valid json
             None,
             TEST_MACHINE_ID,
             Some(&after_id),
+            None,
             &mut output,
         )
         .unwrap();
@@ -2436,6 +2517,7 @@ not valid json
             &data_dir,
             Some(opencode_db.as_path()),
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -2497,6 +2579,7 @@ not valid json
             &data_dir,
             Some(opencode_db.as_path()),
             TEST_MACHINE_ID,
+            None,
             None,
             &mut output,
         )
@@ -2582,5 +2665,44 @@ not valid json
         );
         assert_eq!(recovered.tool_call_count, session.tool_call_count);
         assert_eq!(machine_id, Some("test-machine".to_string()));
+
+        #[test]
+        fn test_since_parameter_threading() {
+            // Test that since parameter is threaded through run_impl to export_opencode_events
+            let (_temp, data_dir, claude_dir) = setup_test_dirs();
+            let db_path = create_test_opencode_db(&data_dir);
+            let mut output = Cursor::new(Vec::new());
+
+            // Create a test session with a known timestamp
+            let session_id = "test-since-session";
+            let created_ms = Utc
+                .with_ymd_and_hms(2026, 1, 1, 12, 0, 0)
+                .unwrap()
+                .timestamp_millis();
+            let updated_ms = Utc
+                .with_ymd_and_hms(2026, 1, 1, 13, 0, 0)
+                .unwrap()
+                .timestamp_millis();
+            insert_opencode_session(&db_path, session_id, "/test/path", created_ms, updated_ms);
+
+            // Test with since = None (should export all sessions)
+            let result = run_impl(
+                &data_dir,
+                &claude_dir,
+                &data_dir,
+                Some(&db_path),
+                TEST_MACHINE_ID,
+                None,
+                None,
+                &mut output,
+            );
+
+            assert!(result.is_ok());
+            let output_str = String::from_utf8(output.get_ref().clone()).unwrap();
+            assert!(
+                output_str.contains(session_id),
+                "session should be exported when since is None"
+            );
+        }
     }
 }

--- a/crates/tt-cli/src/commands/export.rs
+++ b/crates/tt-cli/src/commands/export.rs
@@ -308,10 +308,6 @@ fn run_impl(
 /// Exports tmux events from events.jsonl, passing through valid lines.
 /// When `after` is provided, exports events strictly after the matching event
 /// (the marker event itself is excluded).
-///
-/// If the marker event is not found in the file (e.g., after file rotation),
-/// falls back to exporting ALL events. The import side uses `INSERT OR IGNORE`
-/// to handle duplicates, so this is safe.
 fn export_tmux_events(
     events_file: &Path,
     after: Option<&str>,
@@ -320,9 +316,6 @@ fn export_tmux_events(
     let file = File::open(events_file).context("failed to open events.jsonl")?;
     let reader = BufReader::new(file);
     let mut past_marker = after.is_none();
-
-    // Collect lines so we can fall back to exporting all if marker not found.
-    let mut buffered_lines: Vec<String> = Vec::new();
 
     for (line_num, line) in reader.lines().enumerate() {
         let line = match line {
@@ -348,11 +341,7 @@ fn export_tmux_events(
                     }
                 }
             }
-            if !past_marker {
-                // Buffer lines in case we need to fall back to full export.
-                buffered_lines.push(line);
-            }
-            // Skip the marker event itself and everything before it
+            // Skip the marker event itself and everything before it.
             continue;
         }
 
@@ -363,20 +352,6 @@ fn export_tmux_events(
             }
             Err(e) => {
                 tracing::warn!(line = line_num + 1, error = %e, "malformed JSON, skipping");
-            }
-        }
-    }
-
-    // If marker was requested but never found (e.g., file was rotated),
-    // export ALL buffered events. INSERT OR IGNORE on the import side
-    // ensures duplicates are harmless.
-    if after.is_some() && !past_marker {
-        tracing::info!(
-            "marker event not found in events.jsonl (file may have rotated); exporting all events"
-        );
-        for line in &buffered_lines {
-            if serde_json::from_str::<&serde_json::value::RawValue>(line).is_ok() {
-                writeln!(output, "{line}").context("failed to write event")?;
             }
         }
     }
@@ -2479,6 +2454,46 @@ not valid json
         // Should only get the third event (after the marker)
         assert_eq!(lines.len(), 1);
         assert!(lines[0].contains("00:02:00"));
+    }
+
+    #[test]
+    fn test_export_after_missing_marker_exports_nothing() {
+        let (temp, data_dir, _claude_dir) = setup_test_dirs();
+        let events = [
+            format!(
+                r#"{{"id":"{TEST_MACHINE_ID}:remote.tmux:tmux_pane_focus:2025-01-01T00:00:00.000Z:%1","timestamp":"2025-01-01T00:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+            ),
+            format!(
+                r#"{{"id":"{TEST_MACHINE_ID}:remote.tmux:tmux_pane_focus:2025-01-01T00:01:00.000Z:%1","timestamp":"2025-01-01T00:01:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+            ),
+        ];
+        std::fs::write(
+            data_dir.join("events.jsonl"),
+            events.join(
+                "
+",
+            ) + "
+",
+        )
+        .unwrap();
+
+        let missing_after_id =
+            format!("{TEST_MACHINE_ID}:remote.tmux:tmux_pane_focus:2025-01-01T00:09:00.000Z:%1");
+        let mut output = Vec::new();
+        let state_dir = data_dir.clone();
+        run_impl(
+            &data_dir,
+            &temp.path().join(".claude/projects"),
+            &state_dir,
+            None,
+            TEST_MACHINE_ID,
+            Some(&missing_after_id),
+            None,
+            &mut output,
+        )
+        .unwrap();
+
+        assert!(output.is_empty(), "missing marker should export nothing");
     }
 
     #[test]

--- a/crates/tt-cli/src/commands/export.rs
+++ b/crates/tt-cli/src/commands/export.rs
@@ -2665,44 +2665,44 @@ not valid json
         );
         assert_eq!(recovered.tool_call_count, session.tool_call_count);
         assert_eq!(machine_id, Some("test-machine".to_string()));
+    }
 
-        #[test]
-        fn test_since_parameter_threading() {
-            // Test that since parameter is threaded through run_impl to export_opencode_events
-            let (_temp, data_dir, claude_dir) = setup_test_dirs();
-            let db_path = create_test_opencode_db(&data_dir);
-            let mut output = Cursor::new(Vec::new());
+    #[test]
+    fn test_since_parameter_threading() {
+        // Test that since parameter is threaded through run_impl to export_opencode_events
+        let (_temp, data_dir, claude_dir) = setup_test_dirs();
+        let db_path = create_test_opencode_db(&data_dir);
+        let mut output = Cursor::new(Vec::new());
 
-            // Create a test session with a known timestamp
-            let session_id = "test-since-session";
-            let created_ms = Utc
-                .with_ymd_and_hms(2026, 1, 1, 12, 0, 0)
-                .unwrap()
-                .timestamp_millis();
-            let updated_ms = Utc
-                .with_ymd_and_hms(2026, 1, 1, 13, 0, 0)
-                .unwrap()
-                .timestamp_millis();
-            insert_opencode_session(&db_path, session_id, "/test/path", created_ms, updated_ms);
+        // Create a test session with a known timestamp
+        let session_id = "test-since-session";
+        let created_ms = Utc
+            .with_ymd_and_hms(2026, 1, 1, 12, 0, 0)
+            .unwrap()
+            .timestamp_millis();
+        let updated_ms = Utc
+            .with_ymd_and_hms(2026, 1, 1, 13, 0, 0)
+            .unwrap()
+            .timestamp_millis();
+        insert_opencode_session(&db_path, session_id, "/test/path", created_ms, updated_ms);
 
-            // Test with since = None (should export all sessions)
-            let result = run_impl(
-                &data_dir,
-                &claude_dir,
-                &data_dir,
-                Some(&db_path),
-                TEST_MACHINE_ID,
-                None,
-                None,
-                &mut output,
-            );
+        // Test with since = None (should export all sessions)
+        let result = run_impl(
+            &data_dir,
+            &claude_dir,
+            &data_dir,
+            Some(&db_path),
+            TEST_MACHINE_ID,
+            None,
+            None,
+            &mut output,
+        );
 
-            assert!(result.is_ok());
-            let output_str = String::from_utf8(output.get_ref().clone()).unwrap();
-            assert!(
-                output_str.contains(session_id),
-                "session should be exported when since is None"
-            );
-        }
+        assert!(result.is_ok());
+        let output_str = String::from_utf8(output.get_ref().clone()).unwrap();
+        assert!(
+            output_str.contains(session_id),
+            "session should be exported when since is None"
+        );
     }
 }

--- a/crates/tt-cli/src/commands/ingest.rs
+++ b/crates/tt-cli/src/commands/ingest.rs
@@ -376,8 +376,8 @@ pub fn index_sessions(db: &tt_db::Database) -> Result<()> {
     let opencode_db = get_opencode_db_path()?;
     if opencode_db.exists() {
         println!("Scanning OpenCode sessions...");
-        let opencode_sessions =
-            scan_opencode_sessions(&opencode_db).context("failed to scan OpenCode sessions")?;
+        let opencode_sessions = scan_opencode_sessions(&opencode_db, None)
+            .context("failed to scan OpenCode sessions")?;
         println!("  Found {} OpenCode sessions", opencode_sessions.len());
         all_sessions.extend(opencode_sessions);
     }
@@ -397,6 +397,15 @@ pub fn index_sessions(db: &tt_db::Database) -> Result<()> {
         db.insert_events(&events).with_context(|| {
             format!("failed to insert events for session {}", session.session_id)
         })?;
+    }
+
+    // Clean up stale user_message events from sessions that were reclassified
+    // (e.g., Legion workers previously classified as User, now Agent).
+    let cleaned = db
+        .delete_non_user_message_events()
+        .context("failed to clean up stale user_message events")?;
+    if cleaned > 0 {
+        println!("Cleaned {cleaned} stale user_message events from non-user sessions");
     }
 
     println!(
@@ -583,10 +592,14 @@ fn create_session_events(session: &AgentSession, machine_id: Option<&str>) -> Ve
     start_event.data["project_name"] = json!(session.project_name);
     events.push(start_event);
 
-    // User message events
-    for ts in &session.user_message_timestamps {
-        let id_suffix = format!("user_message-{}", ts.timestamp_millis());
-        events.push(make_event(&id_suffix, *ts, EventType::UserMessage));
+    // User message events — only for human-driven sessions.
+    // Non-User sessions (Agent, Subagent) have automated prompts that would
+    // create false focus signals in the allocation algorithm.
+    if session.session_type == tt_core::session::SessionType::User {
+        for ts in &session.user_message_timestamps {
+            let id_suffix = format!("user_message-{}", ts.timestamp_millis());
+            events.push(make_event(&id_suffix, *ts, EventType::UserMessage));
+        }
     }
 
     for (index, ts) in session.tool_call_timestamps.iter().enumerate() {
@@ -624,7 +637,9 @@ fn get_claude_projects_dir() -> PathBuf {
 
 /// Get the `OpenCode` database path.
 fn get_opencode_db_path() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".local/share/opencode/opencode.db"))
+    Ok(dirs::data_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine data directory"))?
+        .join("opencode/opencode.db"))
 }
 
 /// Reads all events from the events file in the specified data directory.
@@ -1446,4 +1461,79 @@ fn test_create_session_events_with_empty_timestamps() {
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].event_type, tt_core::EventType::AgentSession);
     assert_eq!(events[0].action.as_deref(), Some("started"));
+}
+
+#[test]
+fn test_non_user_session_skips_user_message_events() {
+    use chrono::TimeZone;
+    use tt_core::session::{AgentSession, SessionSource, SessionType};
+
+    let ts1 = Utc.with_ymd_and_hms(2026, 2, 2, 10, 5, 0).unwrap();
+    let ts2 = Utc.with_ymd_and_hms(2026, 2, 2, 10, 10, 0).unwrap();
+
+    // Agent session (e.g., Legion worker) with user_message_timestamps
+    let session = AgentSession {
+        session_id: "ses_legion_worker".to_string(),
+        source: SessionSource::OpenCode,
+        parent_session_id: None,
+        session_type: SessionType::Agent,
+        project_path: "/home/ubuntu/.local/share/legion/workspaces/test".to_string(),
+        project_name: "test".to_string(),
+        start_time: Utc.with_ymd_and_hms(2026, 2, 2, 10, 0, 0).unwrap(),
+        end_time: Some(Utc.with_ymd_and_hms(2026, 2, 2, 11, 0, 0).unwrap()),
+        message_count: 4,
+        summary: None,
+        user_prompts: vec!["automated prompt".to_string()],
+        starting_prompt: Some("automated prompt".to_string()),
+        assistant_message_count: 2,
+        tool_call_count: 100,
+        user_message_timestamps: vec![ts1, ts2],
+        tool_call_timestamps: vec![ts1, ts2],
+    };
+
+    let events = create_session_events(&session, None);
+
+    // Should have: session_start + 2 tool_use + session_end = 4 events
+    // Should NOT have any UserMessage events
+    assert_eq!(events.len(), 4);
+    for event in &events {
+        assert_ne!(
+            event.event_type,
+            tt_core::EventType::UserMessage,
+            "Agent sessions must not emit UserMessage events"
+        );
+    }
+}
+
+#[test]
+fn test_subagent_session_skips_user_message_events() {
+    use chrono::TimeZone;
+    use tt_core::session::{AgentSession, SessionSource, SessionType};
+
+    let ts1 = Utc.with_ymd_and_hms(2026, 2, 2, 10, 5, 0).unwrap();
+
+    let session = AgentSession {
+        session_id: "ses_subagent".to_string(),
+        source: SessionSource::OpenCode,
+        parent_session_id: Some("ses_parent".to_string()),
+        session_type: SessionType::Subagent,
+        project_path: "/home/ubuntu/project".to_string(),
+        project_name: "project".to_string(),
+        start_time: Utc.with_ymd_and_hms(2026, 2, 2, 10, 0, 0).unwrap(),
+        end_time: None,
+        message_count: 2,
+        summary: None,
+        user_prompts: vec!["parent prompt".to_string()],
+        starting_prompt: Some("parent prompt".to_string()),
+        assistant_message_count: 1,
+        tool_call_count: 0,
+        user_message_timestamps: vec![ts1],
+        tool_call_timestamps: Vec::new(),
+    };
+
+    let events = create_session_events(&session, None);
+
+    // Should have only session_start — no UserMessage, no end
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, tt_core::EventType::AgentSession);
 }

--- a/crates/tt-cli/src/commands/sync.rs
+++ b/crates/tt-cli/src/commands/sync.rs
@@ -5,6 +5,8 @@ use std::io::Read;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Duration, Utc};
+use flate2::read::GzDecoder;
 
 use crate::commands::{import, ingest, recompute};
 
@@ -27,8 +29,21 @@ pub fn run(db: &tt_db::Database, remotes: &[String]) -> Result<()> {
 /// Syncs events from a single remote.
 fn sync_single(db: &tt_db::Database, remote: &str) -> Result<()> {
     let last_event_id = db.get_machine_last_event_id_by_label(remote)?;
+    let last_sync_at = db.get_machine_last_sync_at_by_label(remote)?;
 
     let mut export_cmd = String::from("tt export");
+
+    // Add --since flag if we have a previous sync timestamp (with 5-minute overlap for clock skew)
+    if let Some(ref sync_ts) = last_sync_at {
+        if let Ok(last_sync_dt) = DateTime::parse_from_rfc3339(sync_ts) {
+            let since_dt = last_sync_dt.with_timezone(&Utc) - Duration::minutes(5);
+            let since_str = since_dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+            let _ = write!(export_cmd, " --since {since_str}");
+        } else {
+            tracing::warn!(timestamp = %sync_ts, "invalid last_sync_at format, skipping --since");
+        }
+    }
+
     if let Some(ref last_id) = last_event_id {
         // Validate UUID prefix format before using in SSH command to prevent injection
         if last_id.len() > 36
@@ -41,10 +56,13 @@ fn sync_single(db: &tt_db::Database, remote: &str) -> Result<()> {
         }
     }
 
+    // Wrap export command with gzip compression via bash pipefail
+    let compressed_cmd = format!("bash -o pipefail -c '{export_cmd} | gzip'");
+
     let mut command = Command::new("ssh");
     command
         .arg(remote)
-        .arg(&export_cmd)
+        .arg(&compressed_cmd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
@@ -56,29 +74,106 @@ fn sync_single_with_command(
     remote: &str,
     command: &mut Command,
 ) -> Result<()> {
-    let mut child = command
-        .spawn()
-        .with_context(|| format!("failed to SSH to {remote}"))?;
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| anyhow::anyhow!("failed to get SSH stdout"))?;
+    let program = command.get_program().to_owned();
+    let args: Vec<std::ffi::OsString> = command.get_args().map(std::ffi::OsString::from).collect();
+    let current_dir = command
+        .get_current_dir()
+        .map(std::borrow::ToOwned::to_owned);
+    let envs: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)> = command
+        .get_envs()
+        .map(|(key, value)| (key.to_owned(), value.map(std::borrow::ToOwned::to_owned)))
+        .collect();
 
-    let result = import::import_from_reader(db, stdout)?;
+    let retry_args = {
+        let mut stripped_args = Vec::with_capacity(args.len());
+        let mut iter = args.iter();
+        let mut removed_since = false;
 
-    let status = child
-        .wait()
-        .with_context(|| format!("failed to wait for SSH child on {remote}"))?;
+        while let Some(arg) = iter.next() {
+            if arg == "--since" {
+                removed_since = true;
+                let _ = iter.next();
+                continue;
+            }
+            stripped_args.push(arg.clone());
+        }
 
-    let mut stderr_buf = String::new();
-    if let Some(mut stderr) = child.stderr.take() {
-        let _ = stderr.read_to_string(&mut stderr_buf);
-    }
+        removed_since.then_some(stripped_args)
+    };
+
+    let build_command = |attempt_args: &[std::ffi::OsString]| {
+        let mut attempt = Command::new(&program);
+        attempt.args(attempt_args);
+        if let Some(dir) = current_dir.as_deref() {
+            attempt.current_dir(dir);
+        }
+        for (key, value) in &envs {
+            match value {
+                Some(value) => {
+                    attempt.env(key, value);
+                }
+                None => {
+                    attempt.env_remove(key);
+                }
+            }
+        }
+        attempt.stdout(Stdio::piped()).stderr(Stdio::piped());
+        attempt
+    };
+
+    let run_attempt = |attempt_args: &[std::ffi::OsString]| -> Result<_> {
+        let mut child = build_command(attempt_args)
+            .spawn()
+            .with_context(|| format!("failed to SSH to {remote}"))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("failed to get SSH stdout"))?;
+
+        // Wrap stdout in GzDecoder to decompress on-the-fly.
+        let decoder = GzDecoder::new(stdout);
+        let import_result = import::import_from_reader(db, decoder);
+
+        let status = child
+            .wait()
+            .with_context(|| format!("failed to wait for SSH child on {remote}"))?;
+
+        let mut stderr_buf = String::new();
+        if let Some(mut stderr) = child.stderr.take() {
+            let _ = stderr.read_to_string(&mut stderr_buf);
+        }
+
+        Ok((import_result, status, stderr_buf))
+    };
+
+    let (mut result, status, stderr_buf) = run_attempt(&args)?;
 
     if !status.success() {
-        bail!("remote tt export failed on {remote}: {stderr_buf}");
+        if let Some(retry_args) = retry_args {
+            // Older remotes do not understand `tt export --since`; retry once without it
+            // so previously synced machines can still fall back to a full export.
+            tracing::warn!(
+                remote = remote,
+                stderr = %stderr_buf,
+                "remote tt export failed with --since; retrying without it for backward compatibility"
+            );
+
+            let (retry_result, retry_status, retry_stderr) = run_attempt(&retry_args)?;
+            if !retry_status.success() {
+                bail!(
+                    "remote tt export failed on {remote} after retrying without --since: {retry_stderr}"
+                );
+            }
+            result = retry_result;
+        } else {
+            bail!("remote tt export failed on {remote}: {stderr_buf}");
+        }
     }
+
+    let result = result?;
 
     println!(
         "  Imported {} events, {} sessions ({} duplicates, {} malformed)",
@@ -86,7 +181,9 @@ fn sync_single_with_command(
     );
     if let Some(ref mid) = result.machine_id {
         let new_last_id = db.get_latest_event_id_for_machine(mid)?;
-        db.upsert_machine(mid, remote, new_last_id.as_deref())?;
+        let now_utc = Utc::now();
+        let now_str = now_utc.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        db.upsert_machine_with_sync_time(mid, remote, new_last_id.as_deref(), &now_str)?;
     } else {
         tracing::warn!(
             remote = remote,
@@ -100,9 +197,13 @@ fn sync_single_with_command(
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
+    use std::io::Write;
     use std::process::{Command, Stdio};
 
     use anyhow::Result;
+    use flate2::Compression;
+    use flate2::read::GzDecoder;
+    use flate2::write::GzEncoder;
     use tt_db::Database;
 
     use super::sync_single_with_command;
@@ -122,6 +223,18 @@ mod tests {
         format!(
             r#"{{"id":"{id}","timestamp":"{ts}","source":"remote.tmux","type":"tmux_pane_focus","data":{{}}}}"#
         )
+    }
+
+    fn compress_jsonl(jsonl: &str) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(jsonl.as_bytes()).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn make_gzip_script(jsonl: &str) -> String {
+        // Create a script that outputs the JSONL and pipes it through gzip
+        // We need to be careful with quoting to avoid shell injection
+        format!("printf '%s' '{}' | gzip", jsonl.replace('\'', "'\\''"))
     }
 
     #[test]
@@ -185,7 +298,7 @@ mod tests {
             r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
         );
 
-        let script = format!("printf '%s\\n' '{jsonl}'");
+        let script = make_gzip_script(&jsonl);
         run_with_shell(&db, "streaming-remote", &script)?;
 
         let events = db.get_events(None, None)?;
@@ -200,7 +313,9 @@ mod tests {
     #[test]
     fn test_sync_single_empty_export_succeeds() -> Result<()> {
         let db = Database::open_in_memory()?;
-        run_with_shell(&db, "empty-remote", "")?;
+        // Empty gzip stream
+        let script = "printf '' | gzip";
+        run_with_shell(&db, "empty-remote", script)?;
 
         let events = db.get_events(None, None)?;
         assert!(events.is_empty());
@@ -218,8 +333,11 @@ mod tests {
             r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
         );
 
-        let script =
-            format!("printf '%s\\n' '{jsonl}'; printf '%s' 'synthetic ssh failure' >&2; exit 23");
+        // Script that outputs data but then fails
+        let script = format!(
+            "printf '%s' '{}' | gzip; printf '%s' 'synthetic ssh failure' >&2; exit 23",
+            jsonl.replace('\'', "'\\''")
+        );
         let err = run_with_shell(&db, "failing-remote", &script).unwrap_err();
         let err_msg = err.to_string();
         assert!(err_msg.contains("remote tt export failed on failing-remote"));
@@ -227,6 +345,235 @@ mod tests {
 
         let machines = db.list_machines()?;
         assert!(machines.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_single_retries_without_since_after_remote_rejects_flag() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+        let script = format!(
+            r#"if [ "$1" = "--since" ]; then printf '%s' 'unknown option: --since' >&2; exit 64; else printf '%s' '{}' | gzip; fi"#,
+            jsonl.replace('\'', "'\''")
+        );
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(&script)
+            .arg("sh")
+            .arg("--since")
+            .arg("2025-06-01T11:55:00.000Z")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        sync_single_with_command(&db, "compat-remote", &mut command)?;
+
+        let events = db.get_events(None, None)?;
+        assert_eq!(events.len(), 1);
+        let machines = db.list_machines()?;
+        assert_eq!(machines.len(), 1);
+        assert_eq!(machines[0].machine_id, uuid);
+        assert_eq!(machines[0].label, "compat-remote");
+        assert!(machines[0].last_sync_at.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_includes_since_when_last_sync_at_exists() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+
+        // First sync to establish last_sync_at
+        let script = make_gzip_script(&jsonl);
+        run_with_shell(&db, "test-remote", &script)?;
+
+        let machines = db.list_machines()?;
+        assert_eq!(machines.len(), 1);
+        assert!(machines[0].last_sync_at.is_some());
+
+        // Second sync should have last_sync_at set
+        let last_sync_at = db.get_machine_last_sync_at_by_label("test-remote")?;
+        assert!(last_sync_at.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_omits_since_on_first_sync() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+
+        let script = make_gzip_script(&jsonl);
+        run_with_shell(&db, "first-sync-remote", &script)?;
+
+        // On first sync, last_sync_at should be None before the sync
+        let last_sync_at = db.get_machine_last_sync_at_by_label("first-sync-remote")?;
+        // After sync, it should be set
+        assert!(last_sync_at.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_last_sync_at_updated_after_successful_sync() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+
+        let script = make_gzip_script(&jsonl);
+        run_with_shell(&db, "sync-time-remote", &script)?;
+
+        let machines = db.list_machines()?;
+        assert_eq!(machines.len(), 1);
+        assert!(machines[0].last_sync_at.is_some());
+
+        // Verify it's a valid ISO 8601 timestamp
+        let ts = machines[0].last_sync_at.as_ref().unwrap();
+        assert!(ts.contains('T'));
+        assert!(ts.contains('Z'));
+        Ok(())
+    }
+
+    #[test]
+    fn test_last_sync_at_not_updated_after_failed_sync() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+
+        // Attempt a sync that fails
+        let script = format!(
+            "printf '%s' '{}' | gzip; printf '%s' 'synthetic ssh failure' >&2; exit 23",
+            jsonl.replace('\'', "'\\''")
+        );
+        let err = run_with_shell(&db, "failed-sync-remote", &script).unwrap_err();
+        assert!(err.to_string().contains("remote tt export failed"));
+
+        // Verify no machine state was created
+        let machines = db.list_machines()?;
+        assert!(machines.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_gzip_roundtrip_compression_decompression() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+
+        // Compress the JSONL data
+        let compressed = compress_jsonl(&jsonl);
+
+        // Verify compression actually happened (compressed should be smaller or at least different)
+        assert!(!compressed.is_empty());
+        // Gzip header magic bytes: 0x1f 0x8b
+        assert_eq!(compressed[0], 0x1f);
+        assert_eq!(compressed[1], 0x8b);
+
+        // Import the compressed data by wrapping in GzDecoder
+        let reader = Cursor::new(compressed);
+        let decoder = GzDecoder::new(reader);
+        let result = import::import_from_reader(&db, decoder)?;
+
+        // Verify the event was imported correctly
+        assert_eq!(result.inserted, 1);
+        assert_eq!(result.machine_id, Some(uuid.to_string()));
+
+        // Verify the event is in the database
+        let events = db.get_events(None, None)?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, event_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_gzip_multiple_events_roundtrip() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+
+        // Create multiple events
+        let mut jsonl = String::new();
+        for i in 0..5 {
+            let event_id =
+                format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:{i:02}.000Z:%{i}");
+            let event = format!(
+                r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:{i:02}.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%{i}","tmux_session":"main","cwd":"/tmp"}}"#
+            );
+            jsonl.push_str(&event);
+            jsonl.push('\n');
+        }
+
+        // Compress and import
+        let compressed = compress_jsonl(&jsonl);
+        let reader = Cursor::new(compressed);
+        let decoder = GzDecoder::new(reader);
+        let result = import::import_from_reader(&db, decoder)?;
+
+        // Verify all events were imported
+        assert_eq!(result.inserted, 5);
+        assert_eq!(result.machine_id, Some(uuid.to_string()));
+
+        let events = db.get_events(None, None)?;
+        assert_eq!(events.len(), 5);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_gzip_decompression_failure_propagates_error() -> Result<()> {
+        let db = Database::open_in_memory()?;
+
+        // Create invalid gzip data (not actually gzip)
+        let invalid_gzip = b"this is not gzip data";
+        let reader = Cursor::new(invalid_gzip.to_vec());
+        let decoder = GzDecoder::new(reader);
+
+        // Attempt to import invalid gzip data
+        let result = import::import_from_reader(&db, decoder);
+
+        // Should fail with decompression error
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            !err_msg.is_empty(),
+            "Expected error message but got: {err_msg}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_pipefail_propagates_export_failure() -> Result<()> {
+        let db = Database::open_in_memory()?;
+
+        // Script that fails before piping to gzip - pipefail should cause the whole pipeline to fail
+        // We use bash -o pipefail to match the real behavior
+        let script = "bash -o pipefail -c 'exit 42 | gzip'";
+        let err = run_with_shell(&db, "pipefail-test", script).unwrap_err();
+        let err_msg = err.to_string();
+
+        // Should report the failure
+        assert!(err_msg.contains("remote tt export failed on pipefail-test"));
+
         Ok(())
     }
 }

--- a/crates/tt-cli/src/commands/sync.rs
+++ b/crates/tt-cli/src/commands/sync.rs
@@ -1,8 +1,8 @@
 //! Sync command for pulling events from remote machines via SSH.
 
 use std::fmt::Write;
-use std::io::Cursor;
-use std::process::Command;
+use std::io::Read;
+use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 
@@ -41,24 +41,44 @@ fn sync_single(db: &tt_db::Database, remote: &str) -> Result<()> {
         }
     }
 
-    let output = Command::new("ssh")
+    let mut command = Command::new("ssh");
+    command
         .arg(remote)
         .arg(&export_cmd)
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    sync_single_with_command(db, remote, &mut command)
+}
+
+fn sync_single_with_command(
+    db: &tt_db::Database,
+    remote: &str,
+    command: &mut Command,
+) -> Result<()> {
+    let mut child = command
+        .spawn()
         .with_context(|| format!("failed to SSH to {remote}"))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("remote tt export failed on {remote}: {stderr}");
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("failed to get SSH stdout"))?;
+
+    let result = import::import_from_reader(db, stdout)?;
+
+    let status = child
+        .wait()
+        .with_context(|| format!("failed to wait for SSH child on {remote}"))?;
+
+    let mut stderr_buf = String::new();
+    if let Some(mut stderr) = child.stderr.take() {
+        let _ = stderr.read_to_string(&mut stderr_buf);
     }
 
-    if output.stdout.is_empty() {
-        println!("  No new events from {remote}");
-        return Ok(());
+    if !status.success() {
+        bail!("remote tt export failed on {remote}: {stderr_buf}");
     }
-
-    let reader = Cursor::new(output.stdout);
-    let result = import::import_from_reader(db, reader)?;
 
     println!(
         "  Imported {} events, {} sessions ({} duplicates, {} malformed)",
@@ -80,10 +100,23 @@ fn sync_single(db: &tt_db::Database, remote: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
+    use std::process::{Command, Stdio};
 
+    use anyhow::Result;
     use tt_db::Database;
 
+    use super::sync_single_with_command;
     use crate::commands::import;
+
+    fn run_with_shell(db: &Database, remote: &str, script: &str) -> Result<()> {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(script)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        sync_single_with_command(db, remote, &mut command)
+    }
 
     fn make_jsonl_event(id: &str, ts: &str) -> String {
         format!(
@@ -141,5 +174,59 @@ mod tests {
 
         assert_eq!(result.inserted, 1);
         assert_eq!(result.machine_id, None);
+    }
+
+    #[test]
+    fn test_sync_single_streams_child_stdout_into_importer() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+
+        let script = format!("printf '%s\\n' '{jsonl}'");
+        run_with_shell(&db, "streaming-remote", &script)?;
+
+        let events = db.get_events(None, None)?;
+        assert_eq!(events.len(), 1);
+        let machines = db.list_machines()?;
+        assert_eq!(machines.len(), 1);
+        assert_eq!(machines[0].machine_id, uuid);
+        assert_eq!(machines[0].label, "streaming-remote");
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_single_empty_export_succeeds() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        run_with_shell(&db, "empty-remote", "")?;
+
+        let events = db.get_events(None, None)?;
+        assert!(events.is_empty());
+        let machines = db.list_machines()?;
+        assert!(machines.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_single_non_zero_exit_errors_and_does_not_update_machine_state() -> Result<()> {
+        let db = Database::open_in_memory()?;
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let event_id = format!("{uuid}:remote.tmux:tmux_pane_focus:2025-06-01T12:00:00.000Z:%1");
+        let jsonl = format!(
+            r#"{{"id":"{event_id}","timestamp":"2025-06-01T12:00:00.000Z","source":"remote.tmux","type":"tmux_pane_focus","pane_id":"%1","tmux_session":"main","cwd":"/tmp"}}"#
+        );
+
+        let script =
+            format!("printf '%s\\n' '{jsonl}'; printf '%s' 'synthetic ssh failure' >&2; exit 23");
+        let err = run_with_shell(&db, "failing-remote", &script).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("remote tt export failed on failing-remote"));
+        assert!(err_msg.contains("synthetic ssh failure"));
+
+        let machines = db.list_machines()?;
+        assert!(machines.is_empty());
+        Ok(())
     }
 }

--- a/crates/tt-cli/src/main.rs
+++ b/crates/tt-cli/src/main.rs
@@ -59,9 +59,9 @@ fn main() -> Result<()> {
                 ingest::index_sessions(&db)?;
             }
         },
-        Some(Commands::Export { after }) => {
+        Some(Commands::Export { after, since }) => {
             // Export doesn't need config - just reads files and outputs to stdout
-            export::run(after.as_deref())?;
+            export::run(after.as_deref(), since.as_deref())?;
         }
         Some(Commands::Import) => {
             let (db, _config) = open_database(cli.config.as_deref())?;

--- a/crates/tt-core/src/allocation.rs
+++ b/crates/tt-core/src/allocation.rs
@@ -31,7 +31,7 @@ pub struct AllocationConfig {
 impl Default for AllocationConfig {
     fn default() -> Self {
         Self {
-            attention_window_ms: 300_000, // 5 minutes
+            attention_window_ms: 120_000, // 2 minutes
             agent_timeout_ms: 1_800_000,  // 30 minutes
         }
     }

--- a/crates/tt-core/src/allocation.rs
+++ b/crates/tt-core/src/allocation.rs
@@ -31,7 +31,7 @@ pub struct AllocationConfig {
 impl Default for AllocationConfig {
     fn default() -> Self {
         Self {
-            attention_window_ms: 120_000, // 2 minutes
+            attention_window_ms: 300_000, // 5 minutes
             agent_timeout_ms: 1_800_000,  // 30 minutes
         }
     }

--- a/crates/tt-core/src/opencode.rs
+++ b/crates/tt-core/src/opencode.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use chrono::{DateTime, TimeZone, Utc};
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, OpenFlags, params};
 
 use crate::session::{
     AgentSession, MAX_USER_MESSAGE_TIMESTAMPS, MAX_USER_PROMPTS, SessionError, SessionSource,
@@ -37,7 +37,10 @@ struct MessageStats {
     last_message_time: Option<i64>,
 }
 
-pub fn scan_opencode_sessions(db_path: &Path) -> Result<Vec<AgentSession>, SessionError> {
+pub fn scan_opencode_sessions(
+    db_path: &Path,
+    since: Option<DateTime<Utc>>,
+) -> Result<Vec<AgentSession>, SessionError> {
     // NO_MUTEX is safe: single connection used from a single thread (no rayon).
     let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
     let conn = match Connection::open_with_flags(db_path, flags) {
@@ -53,46 +56,91 @@ pub fn scan_opencode_sessions(db_path: &Path) -> Result<Vec<AgentSession>, Sessi
         return Ok(Vec::new());
     }
 
-    let mut stmt = match conn
-        .prepare("SELECT id, directory, title, parent_id, time_created, time_updated FROM session")
-    {
-        Ok(stmt) => stmt,
-        Err(err) => {
-            tracing::warn!(path = ?db_path, error = %err, "failed to query OpenCode sessions");
-            return Ok(Vec::new());
-        }
-    };
-
-    let session_rows = match stmt.query_map([], |row| {
-        Ok(SessionRow {
-            id: row.get::<_, String>(0)?,
-            directory: row.get::<_, String>(1)?,
-            title: row.get::<_, String>(2)?,
-            parent_id: row.get::<_, Option<String>>(3)?,
-            time_created: row.get::<_, i64>(4)?,
-            time_updated: row.get::<_, i64>(5)?,
-        })
-    }) {
-        Ok(rows) => rows,
-        Err(err) => {
-            tracing::warn!(path = ?db_path, error = %err, "failed to iterate OpenCode sessions");
-            return Ok(Vec::new());
-        }
-    };
-
     let mut sessions = Vec::new();
-    for session_row in session_rows {
-        match session_row {
-            Ok(row) => {
-                if let Err(err) = build_agent_session(&conn, row).map(|s| sessions.push(s)) {
-                    tracing::warn!(error = %err, "skipping invalid OpenCode session");
+
+    if let Some(ts) = since {
+        let mut stmt = match conn.prepare(
+            "SELECT id, directory, title, parent_id, time_created, time_updated FROM session \
+             WHERE time_updated > ?",
+        ) {
+            Ok(stmt) => stmt,
+            Err(err) => {
+                tracing::warn!(path = ?db_path, error = %err, "failed to query OpenCode sessions");
+                return Ok(Vec::new());
+            }
+        };
+
+        match stmt.query_map(params![ts.timestamp_millis()], |row| {
+            Ok(SessionRow {
+                id: row.get::<_, String>(0)?,
+                directory: row.get::<_, String>(1)?,
+                title: row.get::<_, String>(2)?,
+                parent_id: row.get::<_, Option<String>>(3)?,
+                time_created: row.get::<_, i64>(4)?,
+                time_updated: row.get::<_, i64>(5)?,
+            })
+        }) {
+            Ok(rows) => {
+                for session_row in rows {
+                    match session_row {
+                        Ok(row) => {
+                            if let Err(err) = build_agent_session(&conn, row).map(|s| sessions.push(s)) {
+                                tracing::warn!(error = %err, "skipping invalid OpenCode session");
+                            }
+                        }
+                        Err(err) => {
+                            tracing::warn!(error = %err, "skipping invalid OpenCode session row");
+                        }
+                    }
                 }
             }
             Err(err) => {
-                tracing::warn!(error = %err, "skipping invalid OpenCode session row");
+                tracing::warn!(path = ?db_path, error = %err, "failed to iterate OpenCode sessions");
+                return Ok(Vec::new());
+            }
+        }
+    } else {
+        let mut stmt = match conn.prepare(
+            "SELECT id, directory, title, parent_id, time_created, time_updated FROM session",
+        ) {
+            Ok(stmt) => stmt,
+            Err(err) => {
+                tracing::warn!(path = ?db_path, error = %err, "failed to query OpenCode sessions");
+                return Ok(Vec::new());
+            }
+        };
+
+        match stmt.query_map([], |row| {
+            Ok(SessionRow {
+                id: row.get::<_, String>(0)?,
+                directory: row.get::<_, String>(1)?,
+                title: row.get::<_, String>(2)?,
+                parent_id: row.get::<_, Option<String>>(3)?,
+                time_created: row.get::<_, i64>(4)?,
+                time_updated: row.get::<_, i64>(5)?,
+            })
+        }) {
+            Ok(rows) => {
+                for session_row in rows {
+                    match session_row {
+                        Ok(row) => {
+                            if let Err(err) = build_agent_session(&conn, row).map(|s| sessions.push(s)) {
+                                tracing::warn!(error = %err, "skipping invalid OpenCode session");
+                            }
+                        }
+                        Err(err) => {
+                            tracing::warn!(error = %err, "skipping invalid OpenCode session row");
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(path = ?db_path, error = %err, "failed to iterate OpenCode sessions");
+                return Ok(Vec::new());
             }
         }
     }
+
 
     sessions.sort_by_key(|e| e.start_time);
     Ok(sessions)
@@ -431,7 +479,7 @@ mod tests {
             1_700_000_060_000,
         );
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         assert_eq!(sessions.len(), 1);
         let session = &sessions[0];
         assert_eq!(session.session_id, "ses_test1");
@@ -496,7 +544,7 @@ mod tests {
             1_700_000_002_000,
         );
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         let session = &sessions[0];
 
         assert_eq!(session.message_count, 2);
@@ -563,7 +611,7 @@ mod tests {
             1_700_000_003_000,
         );
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         let session = &sessions[0];
 
         assert_eq!(
@@ -704,7 +752,7 @@ mod tests {
             1_700_000_010_000,
         );
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         let session = &sessions[0];
 
         assert_eq!(session.session_type, SessionType::Subagent);
@@ -724,7 +772,7 @@ mod tests {
             1_700_000_000_000,
         );
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         let session = &sessions[0];
 
         assert_eq!(session.message_count, 0);
@@ -755,7 +803,7 @@ mod tests {
             1_700_000_100_000,
         );
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
 
         assert_eq!(sessions.len(), 2);
         // Sorted by start_time
@@ -764,8 +812,180 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_since_none_returns_all_sessions() {
+        let (_temp, db_path) = create_test_db();
+
+        insert_session(
+            &db_path,
+            "ses_old",
+            "/home/user/project-old",
+            "",
+            None,
+            1_700_000_000_000,
+            1_700_000_001_000,
+        );
+        insert_session(
+            &db_path,
+            "ses_new",
+            "/home/user/project-new",
+            "",
+            None,
+            1_700_000_100_000,
+            1_700_000_101_000,
+        );
+
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
+
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].session_id, "ses_old");
+        assert_eq!(sessions[1].session_id, "ses_new");
+    }
+
+    #[test]
+    fn test_scan_since_very_old_timestamp_returns_all_sessions() {
+        let (_temp, db_path) = create_test_db();
+
+        insert_session(
+            &db_path,
+            "ses_a",
+            "/home/user/project-a",
+            "",
+            None,
+            1_700_000_000_000,
+            1_700_000_010_000,
+        );
+        insert_session(
+            &db_path,
+            "ses_b",
+            "/home/user/project-b",
+            "",
+            None,
+            1_700_000_100_000,
+            1_700_000_110_000,
+        );
+
+        let since = Utc.timestamp_millis_opt(1).single().unwrap();
+        let sessions = scan_opencode_sessions(&db_path, Some(since)).unwrap();
+
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[test]
+    fn test_scan_since_between_two_sessions_returns_only_newer_sessions() {
+        let (_temp, db_path) = create_test_db();
+
+        insert_session(
+            &db_path,
+            "ses_before",
+            "/home/user/project-before",
+            "",
+            None,
+            1_700_000_000_000,
+            1_700_000_010_000,
+        );
+        insert_session(
+            &db_path,
+            "ses_after",
+            "/home/user/project-after",
+            "",
+            None,
+            1_700_000_020_000,
+            1_700_000_030_000,
+        );
+
+        let since = Utc
+            .timestamp_millis_opt(1_700_000_015_000)
+            .single()
+            .unwrap();
+        let sessions = scan_opencode_sessions(&db_path, Some(since)).unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "ses_after");
+    }
+
+    #[test]
+    fn test_scan_since_exact_updated_boundary_excludes_equal_timestamp() {
+        let (_temp, db_path) = create_test_db();
+
+        insert_session(
+            &db_path,
+            "ses_exact",
+            "/home/user/project-exact",
+            "",
+            None,
+            1_700_000_000_000,
+            1_700_000_020_000,
+        );
+        insert_session(
+            &db_path,
+            "ses_after",
+            "/home/user/project-after",
+            "",
+            None,
+            1_700_000_030_000,
+            1_700_000_021_000,
+        );
+
+        let since = Utc
+            .timestamp_millis_opt(1_700_000_020_000)
+            .single()
+            .unwrap();
+        let sessions = scan_opencode_sessions(&db_path, Some(since)).unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "ses_after");
+    }
+
+    #[test]
+    fn test_scan_since_very_recent_timestamp_returns_no_sessions() {
+        let (_temp, db_path) = create_test_db();
+
+        insert_session(
+            &db_path,
+            "ses_only",
+            "/home/user/project",
+            "",
+            None,
+            1_700_000_000_000,
+            1_700_000_010_000,
+        );
+
+        let since = Utc
+            .timestamp_millis_opt(1_800_000_000_000)
+            .single()
+            .unwrap();
+        let sessions = scan_opencode_sessions(&db_path, Some(since)).unwrap();
+
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn test_scan_since_includes_updated_old_session() {
+        let (_temp, db_path) = create_test_db();
+
+        insert_session(
+            &db_path,
+            "ses_old_but_updated",
+            "/home/user/project",
+            "",
+            None,
+            1_700_000_000_000,
+            1_700_000_200_000,
+        );
+
+        let since = Utc
+            .timestamp_millis_opt(1_700_000_100_000)
+            .single()
+            .unwrap();
+        let sessions = scan_opencode_sessions(&db_path, Some(since)).unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "ses_old_but_updated");
+    }
+
+    #[test]
     fn test_scan_nonexistent_db() {
-        let result = scan_opencode_sessions(Path::new("/nonexistent")).unwrap();
+        let result = scan_opencode_sessions(Path::new("/nonexistent"), None).unwrap();
         assert!(result.is_empty());
     }
 
@@ -797,7 +1017,7 @@ mod tests {
             );
         }
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         let session = &sessions[0];
 
         assert_eq!(session.user_prompts.len(), MAX_USER_PROMPTS);
@@ -912,7 +1132,7 @@ mod tests {
         )
         .unwrap();
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].message_count, 0);
     }
@@ -940,7 +1160,7 @@ mod tests {
             1_700_000_110_000,
         );
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         // Should only contain the good session
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_id, "ses_good");
@@ -1041,7 +1261,7 @@ mod tests {
         let db_path = temp.path().join("opencode.db");
         fs::write(&db_path, "").unwrap();
 
-        let sessions = scan_opencode_sessions(&db_path).unwrap();
+        let sessions = scan_opencode_sessions(&db_path, None).unwrap();
         assert!(sessions.is_empty());
     }
 }

--- a/crates/tt-core/src/opencode.rs
+++ b/crates/tt-core/src/opencode.rs
@@ -84,7 +84,9 @@ pub fn scan_opencode_sessions(
                 for session_row in rows {
                     match session_row {
                         Ok(row) => {
-                            if let Err(err) = build_agent_session(&conn, row).map(|s| sessions.push(s)) {
+                            if let Err(err) =
+                                build_agent_session(&conn, row).map(|s| sessions.push(s))
+                            {
                                 tracing::warn!(error = %err, "skipping invalid OpenCode session");
                             }
                         }
@@ -124,7 +126,9 @@ pub fn scan_opencode_sessions(
                 for session_row in rows {
                     match session_row {
                         Ok(row) => {
-                            if let Err(err) = build_agent_session(&conn, row).map(|s| sessions.push(s)) {
+                            if let Err(err) =
+                                build_agent_session(&conn, row).map(|s| sessions.push(s))
+                            {
                                 tracing::warn!(error = %err, "skipping invalid OpenCode session");
                             }
                         }
@@ -140,7 +144,6 @@ pub fn scan_opencode_sessions(
             }
         }
     }
-
 
     sessions.sort_by_key(|e| e.start_time);
     Ok(sessions)

--- a/crates/tt-db/src/lib.rs
+++ b/crates/tt-db/src/lib.rs
@@ -851,6 +851,24 @@ impl Database {
         Ok(count as u64)
     }
 
+    /// Deletes `user_message` events belonging to non-user agent sessions.
+    ///
+    /// When sessions are reclassified (e.g., from `user` to `agent`), stale
+    /// `user_message` events from previous ingestions create false focus signals
+    /// in the allocation algorithm. This cleans them up.
+    ///
+    /// Returns the number of events deleted.
+    pub fn delete_non_user_message_events(&self) -> Result<u64, DbError> {
+        let count = self.conn.execute(
+            "DELETE FROM events WHERE type = 'user_message' \
+             AND session_id IN (\
+               SELECT session_id FROM agent_sessions WHERE session_type != 'user'\
+             )",
+            [],
+        )?;
+        Ok(count as u64)
+    }
+
     /// Updates time fields for multiple streams.
     ///
     /// Also clears the `needs_recompute` flag and updates `updated_at`.

--- a/crates/tt-db/src/lib.rs
+++ b/crates/tt-db/src/lib.rs
@@ -1394,6 +1394,26 @@ impl Database {
         Ok(())
     }
 
+    /// Inserts or updates a machine entry with explicit sync timestamp.
+    pub fn upsert_machine_with_sync_time(
+        &self,
+        machine_id: &str,
+        label: &str,
+        last_event_id: Option<&str>,
+        last_sync_at: &str,
+    ) -> Result<(), DbError> {
+        self.conn.execute(
+            "INSERT INTO machines (machine_id, label, last_sync_at, last_event_id)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(machine_id) DO UPDATE SET
+                label = excluded.label,
+                last_sync_at = excluded.last_sync_at,
+                last_event_id = COALESCE(excluded.last_event_id, machines.last_event_id)",
+            params![machine_id, label, last_sync_at, last_event_id],
+        )?;
+        Ok(())
+    }
+
     /// Lists all known machines.
     pub fn list_machines(&self) -> Result<Vec<Machine>, DbError> {
         let mut stmt = self.conn.prepare(
@@ -1420,6 +1440,20 @@ impl Database {
         let mut stmt = self
             .conn
             .prepare("SELECT last_event_id FROM machines WHERE label = ?1")?;
+        let result: Option<Option<String>> = stmt
+            .query_row(params![label], |row| row.get(0))
+            .optional()?;
+        Ok(result.flatten())
+    }
+
+    /// Gets the last sync timestamp for a machine identified by label.
+    pub fn get_machine_last_sync_at_by_label(
+        &self,
+        label: &str,
+    ) -> Result<Option<String>, DbError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT last_sync_at FROM machines WHERE label = ?1")?;
         let result: Option<Option<String>> = stmt
             .query_row(params![label], |row| row.get(0))
             .optional()?;

--- a/specs/design/2026-03-24-automatic-sync-design.md
+++ b/specs/design/2026-03-24-automatic-sync-design.md
@@ -1,0 +1,356 @@
+# Automatic Multi-Machine Event Sync
+
+## Problem
+
+tt collects activity events on 3+ machines (laptop, DevBox-MX, GhostWhisper/RPi) but syncing
+them for unified time reports is painful:
+
+1. **Sync is manual.** `tt sync devbox gpu-server` must be run by hand before every standup.
+   No automation, no background process.
+2. **Sync is hub-centric.** The laptop is the de facto hub because that's where the SQLite DB
+   with all historical data lives. Running sync from a different machine loses that history.
+3. **Sync requires SSH connectivity in the right direction.** The laptop pulls from remotes.
+   If the laptop is behind NAT or offline, no sync happens. Remotes can't push.
+4. **No "fleet" model.** Machines are cattle but treated like pets. You want to run `tt report`
+   from any machine and get the same answer.
+
+## Constraints
+
+### Hard Constraints (non-negotiable)
+
+- **Allocation algorithm is centralized.** `allocate_time()` requires ALL events from a time
+  period in one place to compute focus timelines, agent session overlaps, and attention windows.
+  Cannot be distributed across machines.
+- **Data sensitivity.** Events contain `cwd` (filesystem paths), `project_path`, `user_prompts`,
+  and `starting_prompt` — may include proprietary code, API keys, internal project names.
+  Must be encrypted in transit. At-rest encryption strongly preferred.
+- **Offline tolerance.** The laptop goes offline for hours (sleep, travel). The RPi may have
+  intermittent connectivity. Events must accumulate locally and sync when connectivity returns.
+- **Append-only events.** Events are immutable once written. IDs are deterministic
+  (`{machine_uuid}:{source}:{type}:{timestamp}:{discriminator}`). This means merge = set union
+  by ID. No conflict resolution needed for events themselves.
+
+### Soft Constraints (preferences)
+
+- Minimal operational overhead (no Kubernetes, no managed databases to babysit)
+- Low cost (hobby-scale: 3 machines, ~2-3K events/day/machine, ~1-4 MB/day/machine)
+- Rust-native preferred (avoid shelling out to external processes where possible)
+- Should work with existing `rusqlite` codebase without full rewrite
+
+## Current Architecture
+
+```
+Remote Machine (DevBox-MX, GhostWhisper)
+├── tmux hooks → tt ingest → events.jsonl (append-only, 1MB rotation)
+├── Claude sessions → ~/.claude/projects/*.jsonl
+└── OpenCode sessions → ~/.local/share/opencode/opencode.db
+
+     │ tt sync (SSH pull: tt export --after <last_id> | tt import)
+     ▼
+
+Laptop (Hub)
+├── tt.db (SQLite) — all events, streams, agent_sessions, machines table
+├── tt classify — LLM assigns events to streams
+└── tt report — allocation algorithm computes time per stream
+```
+
+**Key properties of current sync:**
+- Pull-based: hub initiates SSH to remotes, runs `tt export`, pipes to `tt import`
+- Incremental: tracks `last_event_id` per remote machine in `machines` table
+- Idempotent: `INSERT OR IGNORE` handles duplicates (deterministic event IDs)
+- Stream assignments cleared on import (re-inferred after sync)
+- Post-sync: index sessions + recompute allocation
+
+## Data Characteristics
+
+| Data Type | Size/Event | Volume/Day/Machine | Sensitive? |
+|-----------|-----------|-------------------|------------|
+| Tmux pane focus | ~600-800 bytes | 1400-2900 | Paths in `cwd` |
+| AFK changes | ~300 bytes | 5-10 | No |
+| Agent sessions | 10-60 KB | 5-20 | `user_prompts`, `project_path` |
+| Agent tool uses | ~400 bytes | 50-200 | No |
+| User messages | ~500 bytes | 10-50 | Content may be sensitive |
+| **Total** | — | **~2-3K events** | **~1.3-4.2 MB/day** |
+
+Monthly across 3 machines: **~120-380 MB**. Bandwidth is not a concern.
+
+## Solutions Evaluated
+
+### Category 1: SQLite Replication (7 solutions evaluated)
+
+| Solution | Multi-Writer | Offline Writes | Status (Mar 2026) | Verdict |
+|----------|-------------|----------------|-------------------|---------|
+| LiteFS | ❌ | ❌ | ⚠️ Abandoned by Fly.io | Skip |
+| Litestream | ❌ (backup only) | ✅ Primary | ✅ Active | Backup tool, not sync |
+| cr-sqlite | ✅ CRDT | ✅ | ⚠️ Stalled (last release Jan 2024) | Risky |
+| Turso/libSQL | ❌ Single primary | ⚠️ Beta | ✅ Active, good Rust SDK | Viable if offline writes not needed |
+| rqlite | ❌ Raft leader | ❌ Needs quorum | ✅ Active | Requires HTTP rewrite, skip |
+| mvsqlite | ✅ | ❌ Needs FoundationDB | ⚠️ Stalled | Way overkill, skip |
+| Electric SQL | ✅ | ✅ | Pivoted to Postgres | No longer SQLite, skip |
+
+**Conclusion:** No drop-in SQLite replication solution fits our multi-writer + offline + Rust
+constraints. cr-sqlite is closest architecturally but development is stalled. Turso/libSQL is
+viable only if we accept a single-primary model (writes fail when offline).
+
+### Category 2: Cloud-Native Sync (7 approaches evaluated)
+
+| Approach | Cost/Month | Complexity | Offline | Rust SDK | Verdict |
+|----------|-----------|-----------|---------|----------|---------|
+| S3 per-machine files | ~$0 | Low | Buffer+upload | ✅ aws-sdk-s3 | **Best fit** |
+| DynamoDB | $0 (free tier) | Low-Med | Buffer+flush | ✅ aws-sdk-dynamodb | Good alternative |
+| SQS/SNS | $0 | High | 14-day queue | ⚠️ Quirks | Overcomplicated |
+| AWS IoT Core | ~$0.05 | Very High | MQTT QoS 1 | ❌ No SDK | Overkill |
+| Syncthing | $0 | Medium | ✅ Native | N/A (daemon) | No-cloud option |
+| sqlite3_rsync | $0 | Low | SSH-dependent | N/A (binary) | Upgrade to current |
+| SSH push | $0 | Low | Buffer+push | ✅ openssh | Complement to any |
+
+**Conclusion:** S3 per-machine event files is the simplest, cheapest cloud option. Each machine
+uploads batch files to its own S3 prefix. `tt sync` pulls from S3 and merges. DynamoDB is a
+good alternative if queryable cloud storage is wanted (future dashboard).
+
+### Category 3: Mesh/P2P Sync (7 solutions evaluated)
+
+| Solution | Rust Maturity | Effort | Encryption | Offline | Verdict |
+|----------|-------------|--------|-----------|---------|---------|
+| crdts (GSet) | ✅ Stable | High (no transport) | DIY | ✅ | Building blocks only |
+| Automerge-rs | ✅ Stable | Medium (sync built-in) | DIY | ✅ | Battle-tested, BYO transport |
+| Loro | ✅ Active | Medium | DIY | ✅ | Newer, great perf |
+| Hypercore-rs | ⚠️ Incomplete | High | ✅ Noise | ✅ | Pre-v1.0, skip |
+| **Iroh + iroh-docs** | ✅ Active (pre-1.0) | **Low** | **✅ QUIC/TLS** | ✅ | **Best P2P option** |
+| Tailscale + custom | ✅ (Tailscale) | Medium | ✅ WireGuard | ✅ | Pragmatic path |
+| Matrix | ✅ Production | High (homeserver) | ✅ Olm | ✅ | Massive overkill |
+
+**Conclusion:** Iroh is the standout P2P option — Rust-native, batteries-included (networking +
+CRDT sync + encryption). Tailscale + Automerge is the pragmatic alternative. Both are viable.
+
+---
+
+## Proposed Approaches
+
+### Approach A: S3 Event Hub (Recommended)
+
+**Architecture:** Each machine pushes event batches to its own S3 prefix. Any machine can pull
+all events from S3 and build a complete local database.
+
+```
+Laptop ──push──► s3://tt-events/laptop/20260324T143022Z.jsonl
+DevBox ──push──► s3://tt-events/devbox/20260324T180011Z.jsonl
+RPi    ──push──► s3://tt-events/rpi/20260324T220033Z.jsonl
+                           │
+                   ◄──pull── tt sync (from ANY machine)
+```
+
+**How it works:**
+1. Each machine runs `tt push` on a timer (cron/systemd, every 5-15 min)
+2. `tt push` reads events.jsonl + sessions since last push, uploads as a batch file to S3
+3. `tt sync` (or `tt pull`) downloads all machine prefixes from S3, merges into local SQLite
+4. Merge is idempotent: event IDs are deterministic, `INSERT OR IGNORE` handles duplicates
+5. Any machine can run sync — no designated hub
+
+**Security:**
+- S3 server-side encryption (SSE-S3 or SSE-KMS) for at-rest
+- HTTPS for in-transit (default with AWS SDK)
+- IAM credentials on each machine (one IAM user, scoped to the bucket)
+- Sensitive fields (user_prompts, cwd) encrypted before upload with a shared symmetric key
+
+**Offline handling:**
+- Events accumulate locally in events.jsonl (already works this way)
+- `tt push` retries on failure, tracks last-pushed position
+- When laptop wakes from sleep, push + sync run automatically
+
+**Pros:**
+- Simplest architecture. No servers, no daemons, no consensus.
+- $0/month at hobby scale (well within S3 free tier)
+- Any machine can be the hub — true "cattle" model
+- Great Rust SDK (`aws-sdk-s3`, mature, async/tokio)
+- Natural upgrade path: add DynamoDB later for queryable data, add Lambda for automation
+
+**Cons:**
+- Requires AWS account + IAM setup (one-time)
+- AWS credentials on each machine (manage with `~/.aws/credentials`)
+- Not real-time (batch interval of 5-15 min, could go to 1 min)
+- Requires internet connectivity for push (no LAN-only fallback)
+- Adds tokio dependency for async AWS SDK (but `#[tokio::main]` already stubbed)
+
+**Estimated effort:** 2-3 days. New `tt push` command, modify `tt sync` to read from S3,
+cron/systemd setup on each machine.
+
+---
+
+### Approach B: Iroh P2P Mesh
+
+**Architecture:** Each machine runs an iroh node. Events sync automatically via iroh-docs
+(CRDT key-value store with range-based set reconciliation).
+
+```
+Laptop ◄──iroh-docs──► DevBox
+   ▲                      ▲
+   └──────iroh-docs───────┘
+              │
+          GhostWhisper
+```
+
+**How it works:**
+1. Each machine runs an iroh endpoint (background process or on-demand)
+2. Events written to a shared iroh-docs "document" (namespace), keyed by event ID
+3. When machines connect (same network or via relay), iroh-docs automatically reconciles
+4. Each machine has a complete local copy of all events at all times
+5. Allocation runs locally on any machine — all events are already there
+
+**Security:**
+- All connections authenticated + encrypted via QUIC/TLS 1.3
+- Node identity = Ed25519 keypair
+- Sensitive payloads encrypted before storing in iroh-docs (application-level)
+
+**Offline handling:**
+- Native. Each machine writes locally. Sync happens when peers reconnect.
+- n0 runs public relay servers for cross-network connectivity
+- Can self-host a relay on the always-on DevBox
+
+**Pros:**
+- True mesh — no central point of failure, no cloud dependency
+- Encryption built-in (QUIC/TLS 1.3 for transport)
+- Handles NAT traversal, hole-punching, relay fallback
+- Rust-native (the whole stack is Rust)
+- Real-time sync when connected (not batch-based)
+- Elegant: event log maps directly to iroh-docs entries
+
+**Cons:**
+- Pre-1.0 (v0.97.0 as of Mar 2026) — expect API churn
+- Requires async migration (iroh is tokio-only, current codebase is sync)
+- Need a relay for cross-network sync (n0 public relays, or self-host)
+- More complex operationally (iroh daemon/process management)
+- Newer, less battle-tested than S3
+- Larger dependency footprint (QUIC stack, crypto, networking)
+
+**Estimated effort:** 5-7 days. Async migration for sync commands, iroh integration,
+key management, relay setup, testing across network topologies.
+
+---
+
+### Approach C: Tailscale + Enhanced SSH Sync (Evolutionary)
+
+**Architecture:** Use Tailscale as the networking layer (WireGuard mesh VPN). Enhance existing
+`tt sync` with push model and automation. Lowest-risk path.
+
+```
+             Tailscale Mesh (WireGuard)
+         ┌──────────────────────────────────┐
+         │                                  │
+Laptop ◄─┤── tt sync (SSH over Tailscale) ──├─► DevBox
+(100.x)  │                                  │   (100.x)
+         │          GhostWhisper            │
+         │            (100.x)               │
+         └──────────────────────────────────┘
+```
+
+**How it works:**
+1. Install Tailscale on all 3 machines (free tier covers this)
+2. Machines get stable `100.x.x.x` IPs + MagicDNS hostnames
+3. Enhance `tt sync` to support both push and pull:
+   - `tt sync --push devbox` — push my events to devbox
+   - `tt sync --pull devbox` — pull devbox events to me (existing behavior)
+4. Add systemd timer: on reconnect, push events to all known peers
+5. Any machine can be the hub — just pull from all others
+6. Add Litestream for S3 backup safety on the primary machine
+
+**Security:**
+- WireGuard encryption for all traffic (ChaCha20-Poly1305)
+- SSH authentication on top (already in place)
+- No data leaves the Tailscale mesh (no cloud storage of events)
+
+**Offline handling:**
+- Events accumulate locally (already works)
+- Tailscale handles reconnection automatically
+- Systemd timer triggers sync on network state change
+
+**Pros:**
+- Minimal code changes — extends existing `tt sync` command
+- Battle-tested security (WireGuard, Tailscale used by millions)
+- No cloud storage of sensitive data (events stay on your machines)
+- Works through NAT, firewalls, mobile networks
+- Free tier covers 3 machines (100 devices)
+- Fastest to implement
+
+**Cons:**
+- Still SSH-based — slower than direct S3 or P2P
+- Tailscale is a centralized coordination service (though data is P2P)
+- One machine still needs to be "the hub" for unified view (unless all push to all)
+- No cloud backup unless you add Litestream separately
+- Tailscale daemon is an external dependency on each machine
+- All-to-all push with 3+ machines creates O(n²) sync traffic (manageable at 3 machines)
+
+**Estimated effort:** 1-2 days. Add push mode to `tt sync`, Tailscale install, systemd timers.
+
+---
+
+## Comparison
+
+| Criterion | A: S3 Hub | B: Iroh Mesh | C: Tailscale+SSH |
+|-----------|-----------|-------------|-----------------|
+| **Complexity** | Low | Medium-High | Very Low |
+| **Cost** | $0 | $0 | $0 |
+| **Implementation time** | 2-3 days | 5-7 days | 1-2 days |
+| **"Run from any machine"** | ✅ Full | ✅ Full | ⚠️ Requires push-to-all |
+| **Offline tolerance** | ✅ Buffer+push | ✅ Native CRDT | ✅ Buffer+push |
+| **Encryption (transit)** | ✅ HTTPS | ✅ QUIC/TLS 1.3 | ✅ WireGuard |
+| **Encryption (at-rest)** | ✅ SSE + app-level | ⚠️ App-level only | ❌ None (local disk) |
+| **Data stays on your machines** | ❌ S3 copy | ✅ Yes | ✅ Yes |
+| **Real-time sync** | ⚠️ Batch (1-15 min) | ✅ Yes | ⚠️ Timer-based |
+| **External dependencies** | AWS SDK | iroh (pre-1.0) | Tailscale daemon |
+| **Maturity** | ✅ Production | ⚠️ Pre-1.0 | ✅ Production |
+| **Rust integration** | ✅ aws-sdk-s3 | ✅ Native Rust | ✅ SSH (existing) |
+| **Future extensibility** | DynamoDB, Lambda | Custom protocols | Limited |
+
+## Recommendation
+
+**Start with Approach A (S3 Hub).** It's the best balance of simplicity, correctness, and
+the "cattle fleet" model you want:
+
+1. Any machine can push events to S3. Any machine can pull and build a complete local DB.
+2. No designated hub — the laptop is no longer special.
+3. S3 is virtually free, highly durable, and you're comfortable with AWS.
+4. The Rust AWS SDK is mature. Implementation is straightforward.
+5. Natural upgrade path: add DynamoDB for queryable data, Lambda for automation.
+
+**Approach C (Tailscale+SSH) is the fast lane** if you want something working this week with
+minimal disruption to the existing codebase.
+
+**Approach B (Iroh) is the most elegant long-term** but carries pre-1.0 risk and larger
+implementation scope. Worth revisiting when iroh reaches 1.0.
+
+**A possible hybrid:** Start with C (Tailscale for networking, immediate improvement to sync),
+then migrate to A (S3 as the durable hub) for the "run from any machine" model. This gives
+you quick wins now and the right architecture later.
+
+---
+
+## Open Questions for Discussion
+
+1. **How critical is "run from any machine"?** If one machine being the hub is acceptable
+   (just with better automation), Approach C is fastest. If true fleet parity is the goal,
+   Approach A is the way.
+
+2. **How sensitive is the data, really?** You mentioned IP concerns. Is this "encrypt before
+   leaving my machines" sensitive, or "encrypt at rest on S3 with KMS" sufficient? This
+   affects whether cloud storage (A) is acceptable or if data must stay on your machines (B/C).
+
+3. **Do you already have Tailscale?** If it's already installed on all 3 machines, Approach C
+   is a 1-day win. If not, the install overhead is similar to AWS credential setup.
+
+4. **Real-time vs. batch sync?** For standup prep, batch sync every 5-15 minutes is fine.
+   Is there a use case where you need events synced within seconds?
+
+5. **Session data handling.** Agent sessions (with sensitive user_prompts) are 10-60 KB each.
+   Should these sync with events, or should session scanning always happen locally on each
+   machine and only metadata (session_id, timestamps, message counts) sync?
+
+6. **Stream assignments.** Currently cleared on import and re-inferred. Should user-assigned
+   streams sync across machines? This would require tracking assignment provenance.
+
+7. **What's the RPi's role?** Is GhostWhisper a development machine (generating events) or
+   could it serve as an always-on hub/relay?
+
+8. **Tolerance for new dependencies?** The S3 approach adds `aws-sdk-s3` + `aws-config` +
+   tokio (for async). The iroh approach adds the entire iroh stack. The Tailscale approach
+   adds almost nothing code-wise. What's your comfort level?

--- a/specs/research/automatic-sync-research.md
+++ b/specs/research/automatic-sync-research.md
@@ -1,0 +1,272 @@
+# Automatic Multi-Machine Sync: Research & Analysis
+
+**Date**: 2026-03-24
+**Status**: Research complete, awaiting discussion
+**Context**: ADR-001 chose SSH pull sync for prototype. Now at 3 machines (laptop, DevBox-MX, GhostWhisper) and the pain is real.
+
+---
+
+## Problem Statement
+
+Daily standup sync takes too long. Must run from the laptop because that's where all data has been ingested. Want any machine to be a first-class participant — "cattle, not pets" — sharing one logical dataset.
+
+### User Requirements (extracted from conversation)
+
+1. **Automatic sync** — when laptop comes online, accumulated events sync without manual `tt sync`
+2. **Any-machine access** — run reports, classify, etc. from any machine
+3. **Fleet mentality** — all machines share one data source
+4. **Security** — Claude/OpenCode session data can contain IP; must be encrypted appropriately
+
+### Current Pain Points
+
+- `tt sync` is manual SSH pull — must remember to run it
+- Must run from laptop (single-machine assumption in the workflow)
+- 3 machines × SSH = slow sequential sync
+- If laptop is offline, can't sync at all
+- No automatic retry or catch-up mechanism
+
+---
+
+## Current Architecture (for context)
+
+```
+Tmux hooks → events.jsonl (per machine)
+Claude/OpenCode sessions → parsed on-demand during export
+tt export → JSONL to stdout (incremental via --after)
+tt sync → SSH to each remote, run tt export, pipe to tt import
+tt import → INSERT OR IGNORE into SQLite (idempotent)
+```
+
+**Key properties that make this tractable:**
+- Events are **append-only** — no updates, no deletes in normal operation
+- Event IDs are **globally unique** — `{machine_uuid}:{source}:{type}:{timestamp}:{discriminator}`
+- Merge is **trivially correct** — `INSERT OR IGNORE` = set union, no conflict resolution needed
+- Data is **small** — 64 KB to 1.3 MB/day/machine, ~10K events/day across all machines
+- Each machine only writes its own events — **no cross-machine writes**
+
+These properties mean we do NOT need CRDTs, consensus protocols, or any distributed systems complexity. The "hard" distributed data problems simply don't apply.
+
+---
+
+## Approaches
+
+### Approach A: File Sync Layer (Syncthing)
+
+**The idea**: Use per-machine event files. Syncthing handles replication transparently.
+
+**How it works**:
+1. Each machine writes to `events-{machine_id}.jsonl` (already has machine-scoped IDs)
+2. Syncthing watches `~/.local/share/time-tracker/` and syncs across all machines
+3. `tt import` reads all peer event files and merges into local SQLite
+4. On startup or periodic schedule, each machine imports peer events
+
+**What changes in `tt`**:
+- Split events.jsonl into per-machine files (small refactor)
+- Add `tt import --from-peers` that scans for peer event files
+- Optionally: systemd timer or cron for periodic local import
+- Remove or simplify `tt sync` (Syncthing replaces SSH transport)
+
+**DO NOT sync SQLite directly** — Syncthing + open SQLite = database corruption. Only sync the JSONL event files and let each machine maintain its own SQLite.
+
+| Pro | Con |
+|-----|-----|
+| Near-zero code changes | Syncthing must run on all 3 machines |
+| Battle-tested sync (81K GitHub stars) | ~1-30s sync latency (fine for time tracking) |
+| Excellent offline support | SQLite stays per-machine (must import after sync) |
+| Peer-to-peer, no cloud needed | Syncthing is another process to manage |
+| Auto-reconnects and catches up | JSONL files grow unbounded (need rotation strategy) |
+| Encrypted in transit (TLS) | At-rest encryption is your responsibility |
+| Works over LAN, Tailscale, or internet | |
+
+**Effort**: ~4 hours (per-machine files + import-from-peers command)
+**Ongoing ops**: Install/configure Syncthing once on each machine
+
+---
+
+### Approach B: Cloud Event Store (AWS)
+
+**The idea**: S3 or DynamoDB as the central event store. Each machine pushes when online, pulls on demand.
+
+#### Option B1: S3 (Simplest cloud option)
+
+```
+Machine A → batch events → PUT s3://tt-events/{machine_id}/{date}.jsonl
+Machine B → GET s3://tt-events/* → merge into local SQLite
+```
+
+- Batch events into daily JSONL files, push every N minutes
+- On sync: download all peer files newer than last-seen timestamp
+- Client-side encryption with `age` crate before upload (zero-knowledge)
+- **Cost: effectively $0** (fits in S3 free tier, then ~$0.01/month)
+
+#### Option B2: DynamoDB (Richer querying)
+
+- Each event is a DynamoDB item: `PK=machine_id, SK=timestamp#event_id`
+- Background thread flushes local SQLite buffer to DynamoDB when online
+- On startup: pull events newer than `last_sync_timestamp` per machine
+- **Cost: $0** (free tier covers 2.5M writes + 2.5M reads/month; you need ~300K/month)
+
+| Pro | Con |
+|-----|-----|
+| Any machine syncs from anywhere | Requires internet connectivity for sync |
+| No peer-to-peer networking needed | AWS account setup + IAM config |
+| Durable cloud backup for free | Vendor lock-in (mild — just JSONL files) |
+| Client-side encryption = zero-knowledge | Additional latency for Raspberry Pi |
+| Scales to any number of machines | More code: AWS SDK integration (~200 LoC) |
+| Works even if machines never see each other | Credential management on 3 machines |
+
+**Effort**: ~2-3 days (AWS SDK integration, encryption, background push/pull)
+**Ongoing ops**: Minimal (AWS free tier, no servers to manage)
+
+---
+
+### Approach C: Self-Hosted Event Relay (Tailscale + `tt serve`)
+
+**The idea**: Each machine runs a tiny HTTP server. Peers sync via HTTP over Tailscale mesh.
+
+```
+Machine A ←──HTTP──→ Machine B ←──HTTP──→ Machine C
+           (all connected via Tailscale WireGuard mesh)
+```
+
+**How it works**:
+1. `tt serve` starts a lightweight axum server bound to Tailscale interface
+2. Exposes: `GET /events?since={timestamp}` → returns JSONL
+3. `tt sync` becomes an HTTP client: polls each peer's `/events` endpoint
+4. Background sync daemon (systemd timer) runs `tt sync` every 5 minutes
+5. Tailscale handles NAT traversal, encryption (WireGuard), device identity
+
+**What this evolves from current design**: The SSH-based sync already works. This replaces SSH with HTTP (simpler, no shell escaping) and Tailscale with direct SSH (no key management, auto NAT traversal).
+
+| Pro | Con |
+|-----|-----|
+| Zero cloud cost | Tailscale must run on all machines |
+| WireGuard encryption (excellent security) | Requires `tt serve` daemon on each machine |
+| Auto NAT traversal | More code than Syncthing approach |
+| Tailscale free tier covers 100 devices | Machines must be online simultaneously for sync |
+| Natural evolution of current SSH sync | Tailscale coordination server sees device metadata |
+| `tt serve` also enables future TUI/API use | |
+
+**Effort**: ~1-2 days (axum server, HTTP sync client, systemd unit)
+**Ongoing ops**: Tailscale free tier, no servers
+
+---
+
+### Approach D: Hybrid (Local-first + Cloud backup)
+
+**The idea**: Combine A or C for fast peer sync with B for cloud durability.
+
+```
+Fast path:  Machine A ←→ Syncthing/Tailscale ←→ Machine B
+Durable:    All machines → S3 (encrypted backup, async)
+Recovery:   New machine → pull from S3 → caught up
+```
+
+This gives you:
+- Fast peer sync when machines are on the same network
+- Cloud backup for durability and "sync from anywhere"
+- New machine onboarding: just pull from S3
+- No single point of failure
+
+| Pro | Con |
+|-----|-----|
+| Best of both worlds | Most complex to implement |
+| Works offline (local sync) AND remotely (cloud) | Two sync paths to maintain |
+| Cloud backup = disaster recovery | May be over-engineering for 3 machines |
+| New machine setup is trivial | |
+
+**Effort**: ~3-5 days (combines A/C + B)
+**Ongoing ops**: Syncthing/Tailscale + AWS free tier
+
+---
+
+## Approaches I Investigated and Rejected
+
+### cr-sqlite (CRDT SQLite extension)
+Architecturally the best fit for true peer-to-peer SQLite sync. **Rejected because**: last release January 2024 (14+ months stale), pre-1.0, 2.5x insert overhead, and your append-only data doesn't need CRDT conflict resolution. The simpler approaches achieve the same result.
+
+### rqlite / dqlite (Raft consensus SQLite)
+**Rejected because**: Raft requires quorum (2 of 3 nodes) for writes. If 2 machines are offline, writes fail. Fundamentally incompatible with offline-first, intermittent-connectivity requirement.
+
+### LiteFS (FUSE-based distributed SQLite)
+**Rejected because**: Single-primary (same as Litestream), requires FUSE (not available everywhere), Fly.io deprioritized development, LiteFS Cloud was sunset October 2024.
+
+### Electric SQL
+**Rejected because**: Postgres-centric, no Rust client, designed for web/mobile apps. Wrong tool entirely.
+
+### Blockchain
+You called it — terrible idea for this. Consensus overhead, storage bloat, and complexity for a problem that has no adversarial trust requirement. Your machines trust each other; you just need reliable data movement.
+
+### NATS JetStream
+Viable as a transport layer but requires running a NATS server somewhere. For 3 machines with append-only data, it's more infrastructure than needed. Would make sense at 10+ machines.
+
+---
+
+## Comparison Matrix
+
+| Factor | A: Syncthing | B: Cloud (S3) | C: Tailscale+HTTP | D: Hybrid |
+|--------|:---:|:---:|:---:|:---:|
+| Code changes | Minimal | Medium | Medium | High |
+| Setup effort | 4 hrs | 2-3 days | 1-2 days | 3-5 days |
+| Ongoing ops | Low | Minimal | Low | Low |
+| Works offline | ✅ | ❌ (needs internet) | ✅ (needs peer) | ✅ |
+| Any-machine access | ✅ | ✅ | ✅ | ✅ |
+| Auto-sync on reconnect | ✅ | ✅ (with daemon) | ✅ (with daemon) | ✅ |
+| Cloud backup | ❌ | ✅ | ❌ | ✅ |
+| New machine onboarding | Pull from peer | Pull from S3 | Pull from peer | Pull from S3 |
+| Security (transit) | TLS | TLS + client encryption | WireGuard | Both |
+| Security (at rest) | Your responsibility | Client-side `age` | Your responsibility | Client-side `age` |
+| Cost | $0 | $0 (free tier) | $0 | $0 |
+| External dependencies | Syncthing daemon | AWS SDK, account | Tailscale, axum | All of the above |
+
+---
+
+## Recommendation
+
+**Start with Approach A (Syncthing)**, evolve to D (Hybrid) if cloud backup becomes important.
+
+### Why A first:
+
+1. **Lowest risk, fastest value** — 4 hours of work, solves the core pain immediately
+2. **No new Rust dependencies** — just restructure event files and add a peer-import command
+3. **Syncthing is battle-tested** — 81K stars, handles reconnection/NAT/encryption out of the box
+4. **Matches your data model perfectly** — per-machine JSONL files, no conflicts, trivial merge
+5. **Non-destructive** — keep `tt sync` SSH as fallback; Syncthing is additive
+
+### What "A done right" looks like:
+
+1. `tt ingest` writes to `events-{machine_id}.jsonl` (not a shared file)
+2. Syncthing syncs `~/.local/share/time-tracker/events-*.jsonl` across machines
+3. `tt refresh` (new command) imports all peer event files into local SQLite
+4. systemd timer runs `tt refresh` every 5 minutes (or on Syncthing file-change event)
+5. `tt classify`, `tt report`, etc. all work locally on merged SQLite — any machine, any time
+6. Claude/OpenCode session scanning runs locally per-machine (sessions stay local, only parsed events sync)
+
+### When to evolve to D:
+
+- If you want cloud backup / disaster recovery
+- If you add a machine that can't run Syncthing (e.g., ephemeral cloud instance)
+- If you want to sync from a machine that has never been peered with Syncthing
+
+### What stays the same regardless of approach:
+
+- Event ID format (`{machine_uuid}:...`) — already globally unique
+- `INSERT OR IGNORE` merge strategy — already idempotent
+- SQLite stays local per machine — never sync the database file
+- Classification and time allocation happen locally after merge
+
+---
+
+## Open Questions for Discussion
+
+1. **Session data sensitivity**: Currently user prompts (truncated to 2000 bytes, max 5) and session summaries are synced. Is that acceptable, or should we encrypt these fields specifically? Or exclude them from sync entirely?
+
+2. **"Run from any machine" scope**: Does this mean full capability (classify, report, tag) from any machine? Or just "all events are available" with classification done from a primary machine? The difference: if classification is per-machine, streams may diverge. If it's synced, we need to sync stream assignments too.
+
+3. **Existing Syncthing/Tailscale setup**: Do you already have Syncthing or Tailscale on these machines? That would affect the recommended approach.
+
+4. **Agent session data locality**: Claude/OpenCode sessions live on the machine where they ran. Currently `tt export` parses them on-demand. Should the parsed session metadata sync across machines, or should each machine only know about its own sessions? (Current behavior: sync sends parsed events + session metadata.)
+
+5. **Standup workflow**: You mentioned standup sync takes forever. Is the bottleneck (a) the SSH connection time, (b) the data transfer volume, (c) the session parsing time, or (d) the manual "remember to run it" overhead? This affects whether we optimize the sync mechanism or just automate the existing one.
+
+6. **JSONL file growth**: events.jsonl currently rotates at 1MB. With per-machine files synced via Syncthing, should we rotate more aggressively? Or archive old events to a separate file that Syncthing ignores?


### PR DESCRIPTION
## Summary

Fix `tt sync` so it handles large remote machines. Was hanging indefinitely on devbox-mx (11K OpenCode sessions, 190MB export). Now completes in ~47 seconds.

### Changes

- **Streaming SSH transport** — Replace `.output()` (buffers all stdout) with `.spawn()` + piped `ChildStdout` directly to `import_from_reader()`. Memory: 190MB → ~1MB.
- **Incremental OpenCode export** — New `--since <timestamp>` flag on `tt export`. Adds `WHERE time_updated > ?` to OpenCode session scan. Sync tracks `last_sync_at` per machine with 5-minute safety overlap for clock skew.
- **Gzip compression** — Remote runs `bash -o pipefail -c 'tt export ... | gzip'`, local decompresses via `flate2::read::GzDecoder`. ~10x smaller over the wire.
- **Backward compatibility** — Retry logic strips `--since` if the remote rejects it (old binary), falling back to full export.

### Additional improvements (from agents)

- Skip `user_message` events for Agent/Subagent sessions (reduces false focus signals in allocation)
- Clean up stale `user_message` events from reclassified sessions on `ingest`
- Use `dirs::data_dir()` instead of hardcoded `~/.local/share` for OpenCode DB path

### Test results

- 377 tests pass, 0 failures
- 0 clippy warnings
- Real-world verified: devbox-mx sync completed (11,704 events), incremental re-sync (35 events), ghost-wispr no regression