### PR TITLE
fix(report): seed cross-boundary agent sessions for accurate daily delegated time

### DIFF
--- a/.opencode/skills/weekly-review/SKILL.md
+++ b/.opencode/skills/weekly-review/SKILL.md
@@ -35,6 +35,7 @@ The file will be created if it doesn't exist. Data is appended (one JSON object 
 5. **Structure**: Present filled form, highlight actual vs perceived gaps
 6. **Challenge**: Red team pushes back on patterns and blind spots
 7. **Save**: Append to JSONL file
+8. **Post-review actions** *(optional)*: Run user-configured follow-up instructions (e.g. 1-on-1 prep, standup draft) defined in `weekly-review.toml` `[post_review_actions]`
 
 ## Critical Constraints
 
@@ -66,6 +67,7 @@ The JSONL path is passed as the skill's `args` parameter:
 - `[goals]` — checkbox items
 - `[ratings]` — rating dimensions and scale
 - `[review]` — output path, week start day
+- `[post_review_actions]` — user-defined freeform instructions for Phase 8
 
 **Ontology config**: Read `~/.config/time-tracker/ontology.toml` for:
 - `projects.names[]` — valid project tags
@@ -349,6 +351,54 @@ On track (personal): Unsure
 
 4. **Show summary**: "Week of Jan 12-18 saved. Review #31."
 
+## Phase 8: Post-Review Actions (optional)
+
+Run any user-configured follow-up actions defined in `~/.config/time-tracker/weekly-review.toml` under `[post_review_actions]`. This is the user's customizable extension point for things they always want to do at the end of a review (1-on-1 prep, drafting standup notes, queuing emails, journaling prompts, etc.).
+
+**This phase is OPTIONAL.** Skip it cleanly if there's no config or the user declines.
+
+### Step 1: Check for config
+
+Look for a `[post_review_actions]` section in `~/.config/time-tracker/weekly-review.toml`. The expected shape is a single freeform `instructions` field:
+
+```toml
+[post_review_actions]
+instructions = """
+<freeform markdown the agent should treat as instructions>
+"""
+```
+
+If the section is missing, empty, or whitespace-only: **skip Phase 8 entirely.** Do not prompt the user. Do not ask them to configure it. Just end the review.
+
+### Step 2: Confirm with the user
+
+If `instructions` is present and non-empty, show a one-line confirmation:
+
+> "Post-review actions configured. Run them now? (y / skip)"
+
+If the user says skip, no, or anything other than affirmative: **end the review.** Do not run the instructions. Do not save the skip anywhere.
+
+### Step 3: Run the instructions
+
+Treat the `instructions` field as a freeform brief from the user about what to do after the review is saved. Read it carefully and execute as written.
+
+**Context the agent has available** (the user can reference any of these in their instructions):
+- The full JSONL entry just saved (last line of the JSONL file)
+- Historical JSONL entries (last 8+ weeks of `reflection`, `ratings`, `red_team`, `next_week`)
+- The `[goals]`, `[ratings]`, and `[prompts]` config
+- The `ontology.toml` taxonomy
+- tt data (run `tt report`, `tt classify` etc. if needed)
+
+**Behavioral guarantees**:
+- Output is **ephemeral** (chat only). Do NOT save action outputs to JSONL. Do NOT modify the just-saved review entry.
+- The freeform instructions are user intent. Follow them as faithfully as the rest of the skill, but do not invent additional follow-ups not requested.
+- If instructions ask for confirmation/iteration with the user, do that.
+- If instructions are unclear or contradict earlier review phases, ask the user to clarify rather than guessing.
+
+### Step 4: Final summary
+
+After completing the actions: "Post-review actions complete." Then end.
+
 ## JSONL Schema
 
 Each line in `weekly-reviews.jsonl` is a JSON object. See the full example in `.opencode/skills/weekly-review/example.json`.
@@ -401,10 +451,13 @@ Other:        ██████████ 20%
 If `~/.config/time-tracker/weekly-review.toml` is missing:
 - Use built-in defaults for reflection questions, goals, ratings
 - Log a note: "No config found — using defaults"
-
 If `~/.config/time-tracker/ontology.toml` is missing:
 - Skip ontology-based organization in Phase 3
 - Present raw tt report data without project/activity grouping
+
+### Post-Review Actions Missing or Skipped (Phase 8)
+If `[post_review_actions]` is absent or `instructions` is empty: skip Phase 8 silently — no prompt, no warning. Phase 8 is optional by design.
+If user declines to run them at the confirmation prompt: end the review without running. Do not save the skip.
 
 ## Edge Cases
 
@@ -435,6 +488,10 @@ If `~/.config/time-tracker/ontology.toml` is missing:
 | Rushing through narration | Let the user talk. Brief acknowledgments only. Don't lead or suggest what they should say. |
 | Including reflect-style analysis | Session pattern analysis is a separate skill. Weekly review focuses on time, goals, and reflection. |
 | Using `tt classify --json` for time data | `classify` shows sessions and clusters, not period-scoped time. Use `tt report` for time within a specific period. |
+| Running Phase 8 instructions without user confirmation | **Always** ask "Run them now? (y / skip)" before executing the freeform instructions. The instructions are opt-in per-review. |
+| Saving Phase 8 action output to JSONL | Phase 8 outputs are **ephemeral**. The just-saved review entry must remain untouched. If the user wants persistence, they update their instructions to write to a different file. |
+| Treating absent `[post_review_actions]` as an error | It's optional. Skip silently. Don't prompt the user to configure it. |
+| Inventing follow-ups beyond user instructions | Phase 8 only does what the freeform `instructions` say. Don't add suggestions, summaries, or actions not requested. |
 
 ## Goal Tracking Checkboxes
 

--- a/crates/tt-cli/src/cli.rs
+++ b/crates/tt-cli/src/cli.rs
@@ -90,6 +90,14 @@ pub enum Commands {
         #[arg(long, value_name = "N", value_parser = clap::value_parser!(u32).range(1..), group = "period")]
         weeks: Option<u32>,
 
+        /// Start date (YYYY-MM-DD, local time). Use with --end for custom range.
+        #[arg(long, group = "period")]
+        start: Option<String>,
+
+        /// End date (YYYY-MM-DD, local time, exclusive). Use with --start for custom range.
+        #[arg(long, requires = "start")]
+        end: Option<String>,
+
         /// Output as JSON.
         #[arg(long)]
         json: bool,

--- a/crates/tt-cli/src/commands/ingest.rs
+++ b/crates/tt-cli/src/commands/ingest.rs
@@ -420,7 +420,7 @@ pub fn index_sessions(db: &tt_db::Database) -> Result<()> {
     }
 
     let mut project_list: Vec<_> = projects.into_iter().collect();
-    project_list.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    project_list.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
 
     println!("\nSessions by project:");
     for (project, count) in &project_list[..project_list.len().min(10)] {

--- a/crates/tt-cli/src/commands/report.rs
+++ b/crates/tt-cli/src/commands/report.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Datelike, Local, LocalResult, NaiveDate, NaiveTime, TimeZone, Utc};
 use serde::Serialize;
 use tt_core::session::AgentSession;
-use tt_core::{AllocationConfig, allocate_time};
+use tt_core::{AllocationConfig, EventType, allocate_time};
 use tt_db::Database;
 
 /// Report period type.
@@ -23,6 +23,7 @@ pub enum Period {
     LastWeek,
     Day,
     LastDay,
+    Custom(DateTime<Utc>, DateTime<Utc>),
 }
 
 /// Period type for JSON output.
@@ -64,7 +65,7 @@ const DEFAULT_WEEK_START_DAY: &str = "monday";
 
 /// Converts a local date at midnight to UTC.
 /// Handles DST ambiguity by picking the earlier time.
-fn local_midnight_to_utc(local_date: NaiveDate) -> DateTime<Utc> {
+pub fn local_midnight_to_utc(local_date: NaiveDate) -> DateTime<Utc> {
     let midnight = local_date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
     match Local.from_local_datetime(&midnight) {
         // Single or ambiguous (DST fall-back): use the earlier time
@@ -128,6 +129,7 @@ pub fn get_period_boundaries(period: Period, today: NaiveDate) -> (DateTime<Utc>
         Period::LastWeek => last_week_boundaries(today),
         Period::Day => day_boundaries(today),
         Period::LastDay => last_day_boundaries(today),
+        Period::Custom(start, end) => (start, end),
     }
 }
 
@@ -286,13 +288,39 @@ pub fn generate_report_data_for_date(
 
     let period_type = match period {
         Period::Week | Period::LastWeek => PeriodType::Week,
-        Period::Day | Period::LastDay => PeriodType::Day,
+        Period::Day | Period::LastDay | Period::Custom(_, _) => PeriodType::Day,
     };
 
     // Get events within the period
-    let events = db
+    let mut events = db
         .get_events_in_range(period_start, period_end)
         .context("failed to get events in period")?;
+
+    let session_ids_with_starts: BTreeSet<&str> = events
+        .iter()
+        .filter(|event| {
+            event.event_type == EventType::AgentSession
+                && event.action.as_deref() == Some("started")
+        })
+        .filter_map(|event| event.session_id.as_deref())
+        .collect();
+    let missing_session_ids: Vec<String> = events
+        .iter()
+        .filter(|event| event.event_type == EventType::AgentToolUse)
+        .filter_map(|event| event.session_id.as_deref())
+        .filter(|session_id| !session_ids_with_starts.contains(*session_id))
+        .map(ToString::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    if !missing_session_ids.is_empty() {
+        let mut start_events = db
+            .get_agent_session_start_events(&missing_session_ids)
+            .context("failed to get agent session starts for period")?;
+        start_events.append(&mut events);
+        events = start_events;
+    }
 
     // Calculate time from events using the allocation algorithm
     let config = AllocationConfig::default();
@@ -830,7 +858,7 @@ mod tests {
     use super::*;
     use chrono::TimeZone;
     use insta::assert_snapshot;
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use tt_core::session::{SessionSource, SessionType};
 
     // ========== Period Date Calculation Tests ==========
@@ -1022,6 +1050,37 @@ mod tests {
             tool_call_count: 0,
             user_message_timestamps: Vec::new(),
             tool_call_timestamps: Vec::new(),
+        }
+    }
+
+    fn make_agent_event(
+        id: &str,
+        timestamp: DateTime<Utc>,
+        event_type: tt_core::EventType,
+        session_id: &str,
+        stream_id: &str,
+        action: Option<&str>,
+    ) -> tt_db::StoredEvent {
+        tt_db::StoredEvent {
+            id: id.to_string(),
+            timestamp,
+            event_type,
+            source: "remote.agent".to_string(),
+            machine_id: None,
+            schema_version: 1,
+            pane_id: None,
+            tmux_session: None,
+            window_index: None,
+            git_project: None,
+            git_workspace: None,
+            status: None,
+            idle_duration_ms: None,
+            action: action.map(ToString::to_string),
+            cwd: Some("/home/sami/time-tracker/default".to_string()),
+            session_id: Some(session_id.to_string()),
+            stream_id: Some(stream_id.to_string()),
+            assignment_source: None,
+            data: json!({}),
         }
     }
 
@@ -1709,5 +1768,108 @@ Delegated time: 3h 13m (36%)
             data.streams.is_empty(),
             "zero-time streams should be excluded"
         );
+    }
+
+    #[test]
+    fn test_day_report_seeds_cross_boundary_agent_session_starts() {
+        let db = tt_db::Database::open_in_memory().unwrap();
+        let reference_date = NaiveDate::from_ymd_opt(2025, 1, 29).unwrap();
+        let (period_start, period_end) = get_period_boundaries(Period::Day, reference_date);
+        let session_id = "session-cross-boundary";
+        let stream_id = "stream-cross-boundary";
+        let stream_created_at = period_start - chrono::Duration::hours(2);
+
+        db.insert_stream(&tt_db::Stream {
+            id: stream_id.to_string(),
+            name: Some("cross-boundary stream".to_string()),
+            created_at: stream_created_at,
+            updated_at: stream_created_at,
+            time_direct_ms: 0,
+            time_delegated_ms: 0,
+            first_event_at: None,
+            last_event_at: None,
+            needs_recompute: false,
+        })
+        .unwrap();
+
+        let session_start = period_start - chrono::Duration::hours(1);
+        let first_tool_use =
+            period_start + chrono::Duration::hours(9) + chrono::Duration::minutes(10);
+        let second_tool_use = first_tool_use + chrono::Duration::minutes(30);
+        let session_end = second_tool_use + chrono::Duration::minutes(20);
+        let expected_delegated_ms = (session_end - first_tool_use).num_milliseconds();
+
+        let start_event = make_agent_event(
+            "session-start",
+            session_start,
+            tt_core::EventType::AgentSession,
+            session_id,
+            stream_id,
+            Some("started"),
+        );
+        let first_tool_event = make_agent_event(
+            "tool-use-1",
+            first_tool_use,
+            tt_core::EventType::AgentToolUse,
+            session_id,
+            stream_id,
+            None,
+        );
+        let second_tool_event = make_agent_event(
+            "tool-use-2",
+            second_tool_use,
+            tt_core::EventType::AgentToolUse,
+            session_id,
+            stream_id,
+            None,
+        );
+        let end_event = make_agent_event(
+            "session-end",
+            session_end,
+            tt_core::EventType::AgentSession,
+            session_id,
+            stream_id,
+            Some("ended"),
+        );
+
+        for event in [
+            &start_event,
+            &first_tool_event,
+            &second_tool_event,
+            &end_event,
+        ] {
+            db.insert_event(event).unwrap();
+        }
+
+        let period_events = db.get_events_in_range(period_start, period_end).unwrap();
+        let config = AllocationConfig::default();
+
+        let without_seed =
+            allocate_time(&period_events, &config, Some(period_end), &HashMap::new());
+        assert_eq!(without_seed.stream_times.len(), 0);
+
+        let mut seeded_events = Vec::with_capacity(period_events.len() + 1);
+        seeded_events.push(start_event);
+        seeded_events.extend(period_events);
+        let with_seed = allocate_time(&seeded_events, &config, Some(period_end), &HashMap::new());
+        assert_eq!(with_seed.stream_times.len(), 1);
+        assert_eq!(with_seed.stream_times[0].stream_id, stream_id);
+        assert_eq!(
+            with_seed.stream_times[0].time_delegated_ms,
+            expected_delegated_ms
+        );
+
+        let data = generate_report_data_for_date(
+            &db,
+            Period::Day,
+            period_end + chrono::Duration::hours(1),
+            reference_date,
+            "Etc/UTC".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(data.streams.len(), 1);
+        assert_eq!(data.streams[0].id, stream_id);
+        assert_eq!(data.streams[0].time_delegated_ms, expected_delegated_ms);
     }
 }

--- a/crates/tt-cli/src/main.rs
+++ b/crates/tt-cli/src/main.rs
@@ -81,10 +81,28 @@ fn main() -> Result<()> {
             day,
             last_day,
             weeks,
+            start,
+            end,
             json,
         }) => {
             let (db, _config) = open_database(cli.config.as_deref())?;
-            let period = if *last_week {
+            let period = if let Some(start_str) = start {
+                let start_date = chrono::NaiveDate::parse_from_str(start_str, "%Y-%m-%d")
+                    .with_context(|| {
+                        format!("invalid --start date '{start_str}', expected YYYY-MM-DD")
+                    })?;
+                let end_date = match end {
+                    Some(end_str) => chrono::NaiveDate::parse_from_str(end_str, "%Y-%m-%d")
+                        .with_context(|| {
+                            format!("invalid --end date '{end_str}', expected YYYY-MM-DD")
+                        })?,
+                    None => chrono::Local::now().date_naive() + chrono::Duration::days(1),
+                };
+                report::Period::Custom(
+                    report::local_midnight_to_utc(start_date),
+                    report::local_midnight_to_utc(end_date),
+                )
+            } else if *last_week {
                 report::Period::LastWeek
             } else if *day {
                 report::Period::Day

--- a/crates/tt-db/src/lib.rs
+++ b/crates/tt-db/src/lib.rs
@@ -32,7 +32,7 @@
 use std::path::Path;
 
 use chrono::{DateTime, SecondsFormat, Utc};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -603,6 +603,39 @@ impl Database {
 
         let mut events = Vec::new();
         let mut rows = stmt.query(params![format_timestamp(start), format_timestamp(end)])?;
+
+        while let Some(row) = rows.next()? {
+            if let Some(event) = Self::row_to_event(row)? {
+                events.push(event);
+            }
+        }
+
+        Ok(events)
+    }
+
+    pub fn get_agent_session_start_events(
+        &self,
+        session_ids: &[String],
+    ) -> Result<Vec<StoredEvent>, DbError> {
+        if session_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders = session_ids
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT id, timestamp, type, source, machine_id, schema_version, cwd, git_project, git_workspace, pane_id, tmux_session, window_index, status, idle_duration_ms, action, session_id, stream_id, assignment_source
+             FROM events
+             WHERE type = 'agent_session' AND action = 'started' AND session_id IN ({placeholders})
+             ORDER BY timestamp ASC"
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut events = Vec::new();
+        let mut rows = stmt.query(params_from_iter(session_ids.iter()))?;
 
         while let Some(row) = rows.next()? {
             if let Some(event) = Self::row_to_event(row)? {
@@ -1744,6 +1777,70 @@ mod tests {
         let start = Utc.with_ymd_and_hms(2025, 1, 15, 11, 0, 0).unwrap();
         let end = Utc.with_ymd_and_hms(2025, 1, 15, 12, 0, 0).unwrap();
         let events = db.get_events_in_range(start, end).unwrap();
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_get_agent_session_start_events_filters_and_orders_results() {
+        let db = Database::open_in_memory().unwrap();
+        let ts1 = Utc.with_ymd_and_hms(2025, 1, 14, 23, 0, 0).unwrap();
+        let ts2 = Utc.with_ymd_and_hms(2025, 1, 15, 0, 0, 0).unwrap();
+        let ts3 = Utc.with_ymd_and_hms(2025, 1, 15, 1, 0, 0).unwrap();
+        let ts4 = Utc.with_ymd_and_hms(2025, 1, 15, 2, 0, 0).unwrap();
+
+        for stream_id in ["stream-a", "stream-b"] {
+            db.insert_stream(&Stream {
+                id: stream_id.to_string(),
+                created_at: ts1,
+                updated_at: ts1,
+                name: Some(stream_id.to_string()),
+                time_direct_ms: 0,
+                time_delegated_ms: 0,
+                first_event_at: None,
+                last_event_at: None,
+                needs_recompute: false,
+            })
+            .unwrap();
+        }
+
+        let mut second_start = make_event("session-b-start", ts2, tt_core::EventType::AgentSession);
+        second_start.action = Some("started".to_string());
+        second_start.session_id = Some("session-b".to_string());
+        second_start.stream_id = Some("stream-b".to_string());
+
+        let mut first_start = make_event("session-a-start", ts1, tt_core::EventType::AgentSession);
+        first_start.action = Some("started".to_string());
+        first_start.session_id = Some("session-a".to_string());
+        first_start.stream_id = Some("stream-a".to_string());
+
+        let mut tool_use = make_event("session-a-tool", ts3, tt_core::EventType::AgentToolUse);
+        tool_use.session_id = Some("session-a".to_string());
+        tool_use.stream_id = Some("stream-a".to_string());
+
+        let mut end = make_event("session-a-end", ts4, tt_core::EventType::AgentSession);
+        end.action = Some("ended".to_string());
+        end.session_id = Some("session-a".to_string());
+        end.stream_id = Some("stream-a".to_string());
+
+        for event in [&second_start, &first_start, &tool_use, &end] {
+            db.insert_event(event).unwrap();
+        }
+
+        let events = db
+            .get_agent_session_start_events(&["session-b".to_string(), "session-a".to_string()])
+            .unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].id, "session-a-start");
+        assert_eq!(events[1].id, "session-b-start");
+    }
+
+    #[test]
+    fn test_get_agent_session_start_events_empty_input() {
+        let db = Database::open_in_memory().unwrap();
+
+        let events = db.get_agent_session_start_events(&[]).unwrap();
 
         assert!(events.is_empty());
     }


### PR DESCRIPTION
## Summary

- `tt report --last-day` showed near-zero delegated time for agent sessions that started before the reporting window
- The allocation algorithm only registers sessions when it sees `AgentSession "started"` events, which fall outside the day boundary for multi-day sessions
- Fix: fetch missing "started" events from the DB and prepend them before running allocation

## Changes

- **tt-db**: Added `Database::get_agent_session_start_events()` — fetches `agent_session` "started" events by session ID
- **tt-cli/report.rs**: `generate_report_data_for_date()` now detects cross-boundary sessions and seeds the allocator
- **Tests**: Regression test proves the bug (0 delegated without seed) and the fix (correct delegated with seed)

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| `--last-day` delegated | 17min | 14.0h |
| `--last-week` delegated | 515.5h (unchanged) | 515.5h |