### PR TITLE
fix(status): pin the clock so status snapshots cannot rot

### DIFF
--- a/crates/tt-cli/src/commands/status.rs
+++ b/crates/tt-cli/src/commands/status.rs
@@ -18,7 +18,18 @@ use crate::drift::{MachineFreshness, Verdict, compute_verdict};
 ///
 /// Returns the formatted output string (for testing).
 pub fn format_status(db: &Database, config: &Config) -> Result<String> {
-    let now = Utc::now();
+    format_status_at(db, config, Utc::now())
+}
+
+/// Formats the status output as of `now`.
+///
+/// The clock is a parameter because this output renders *ages* (`last reported 556d ago`),
+/// so a snapshot taken against `Utc::now()` is only true on the day it was accepted. This
+/// function reading the wall clock is what turned `main` red: green on the pull request,
+/// red seventeen hours later at `556d ago` -> `557d ago`. Re-accepting the snapshot fixes
+/// it until tomorrow; pinning the clock fixes it. `format_age` and `format_machines`
+/// already take a `now` — this was the renderer that swallowed it.
+pub fn format_status_at(db: &Database, config: &Config, now: DateTime<Utc>) -> Result<String> {
     let verdict = compute_verdict(db, config, now).context("failed to compute status verdict")?;
     let statuses = db.get_last_event_per_source()?;
 
@@ -225,6 +236,14 @@ mod tests {
         }
     }
 
+    /// The instant every snapshot in this module is rendered against.
+    ///
+    /// Chosen to reproduce the ages these snapshots were originally accepted with, so
+    /// pinning the clock changed no expected output — it only stopped it drifting.
+    fn snapshot_now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 8, 12, 0, 0).unwrap()
+    }
+
     #[test]
     fn test_status_empty_database() {
         let temp = TempDir::new().unwrap();
@@ -232,7 +251,7 @@ mod tests {
         let db_path = PathBuf::from("/path/to/events.db");
         let config = test_config(&temp, db_path);
 
-        let output = format_status(&db, &config).unwrap();
+        let output = format_status_at(&db, &config, snapshot_now()).unwrap();
 
         assert_snapshot!(output);
     }
@@ -253,7 +272,7 @@ mod tests {
         db.insert_event(&make_event("e2", ts_agent, "remote.agent"))
             .unwrap();
 
-        let output = format_status(&db, &config).unwrap();
+        let output = format_status_at(&db, &config, snapshot_now()).unwrap();
 
         assert_snapshot!(output);
     }


### PR DESCRIPTION
`main` went red on a test that was green on the pull request seventeen hours
earlier, with nothing between the two runs but midnight:

    -      ⚠ tmux_pane_focus stale — ... last reported 556d ago (2025-01-29T11:45:00Z)
    +      ⚠ tmux_pane_focus stale — ... last reported 557d ago (2025-01-29T11:45:00Z)

`format_status` read `Utc::now()` internally while `test_status_with_events`
pinned its fixtures to fixed calendar dates, so the rendered age grew by one
every day. The snapshot was a time bomb with a 24-hour fuse, and it only
started ticking when `tmux_pane_focus` joined `MONITORED_LOCAL_SOURCES` and
that fixture began rendering a stale line at all.

Running `cargo insta review` would have made it pass until tomorrow. The clock
is now a parameter: `format_status_at(db, config, now)` holds the body and
`format_status` is a thin wrapper over it with `Utc::now()`. Both snapshot
tests render against a fixed instant, chosen to reproduce the ages the
snapshots were already accepted with -- so **no expected output changed**, no
snapshot was re-accepted, and the test simply stopped drifting.

`format_age` and `format_machines` already took a `now` for exactly this
reason, which is why the streams and machines snapshots never rotted despite
also containing ages. This was the one renderer that swallowed the clock.

The dedicated staleness test is untouched: it uses relative fixtures and a
line assertion rather than a snapshot, so it was never time-dependent.
