### PR TITLE
docs(specs): plan the allocation, classifier and read-path rearchitecture

### DIFF
--- a/specs/implementation/2026-08-09-allocation-streaming-plan.md
+++ b/specs/implementation/2026-08-09-allocation-streaming-plan.md
@@ -1,0 +1,1078 @@
+# Streaming Allocation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make time allocation stream events instead of materializing the whole history, so `tt recompute` stops costing 250 seconds and 8.9 GB to compute a group-by that SQLite does in 0.73 seconds and 6.4 MB.
+
+**Architecture:** `tt_core::allocation::allocate_time` is *already* a single forward pass over timestamp-sorted events (`for event in events`, state in `HashMap`s, no random access). It only holds the whole history because of its **signature** — it takes `&[E]`. This plan (1) deletes a redundant second full load in `recompute::run`, (2) re-exposes the existing pass as an incremental `Allocator` with `push`/`finish`, (3) feeds it directly from a streaming SQLite query, and (4) parallelizes the per-stream interval union that runs at the end. No allocation *rule* changes. Every number the product reports must come out byte-identical.
+
+**Tech Stack:** Rust (edition 2021), rusqlite 0.34 (streaming via `Statement::query`), rayon 1.10 (already a `tt-core` dependency, already used in `session.rs` and `opencode.rs`), insta snapshots, `anyhow` in `tt-cli` / `thiserror` in `tt-core` + `tt-db`.
+
+## Measured Baseline (re-measure before and after; do not trust these numbers stale)
+
+| | wall | peak RSS | cores |
+|---|---|---|---|
+| `tt recompute` over 2,738,805 events (2.2 GB db) | **250.48 s** | **8,928,316 KB (8.9 GB)** | 99% = 1 of 24 |
+| `sqlite3 "SELECT stream_id, count(*), min(timestamp), max(timestamp) FROM events GROUP BY stream_id"` | **0.73 s** | **6,380 KB** | 1 |
+
+Machine: 24 cores, 89 GB RAM.
+
+Reproduce the baseline with:
+
+```bash
+cd /home/sami/Code/time-tracker/default
+cp ~/.local/share/time-tracker/tt.db /tmp/perf.db
+cargo build --release --bin tt
+TT_DATABASE_PATH=/tmp/perf.db /usr/bin/time -f 'wall=%es cpu=%P peak_rss=%MKB' \
+  ./target/release/tt recompute
+```
+
+## Global Constraints
+
+- **Direct time must not change by one millisecond.** Acceptance for every task: `tt report` for `2026-07-20` prints `Direct time: 16h 23m` and for `2026-07-13..2026-07-20` prints `Direct time: 74h 20m`, against a copy of the live database, before and after.
+- **Delegated time sums across parallel agents by design and routinely exceeds wall clock.** Never union, cap, or clamp delegated intervals. `test_parallel_agent_sessions_sum_delegated_beyond_wall_clock` (`crates/tt-core/src/allocation.rs:2402`) guards this; if it fails the change is wrong, not the test.
+- **Direct time is a union, not a sum**, and can never exceed wall clock: `test_total_direct_time_never_exceeds_wall_clock` (`allocation.rs:2360`).
+- **All 55 `#[test]` cases in `crates/tt-core/src/allocation.rs` must pass unmodified** through Tasks 1–4. If a test needs editing to pass, stop: the behavior changed.
+- `tt_core::allocation::allocate_time` is clippy-blocked for outside callers (`clippy.toml` `disallowed-methods`). `tt_db::allocate_for_period` stays the only permitted entry point. Any new public entry point must be added to that policy deliberately, not by accident.
+- `allocate_for_period`'s `end` is **exclusive**; it queries `start..=end − 1ms` internally. Preserve exactly.
+- Errors: `thiserror` (`DbError`) in `tt-db`, `thiserror` in `tt-core`, `anyhow` + `.context(...)` in `tt-cli`.
+- Lints: workspace denies `unsafe_code`; `clippy::all`/`pedantic`/`nursery` are warnings and CI runs `-D warnings`. **Zero clippy warnings.** Never bare `#[allow]` — use `#[expect(lint, reason = "...")]`.
+- `cargo fmt` clean (`max_width = 100`).
+- No new dependencies. `rayon` is already available to `tt-core` only.
+- **jj, not git.** Commit with `jj describe -m "..."` then `jj new`. Never use `git`. Never use backticks or `$(...)` inside a double-quoted `jj describe -m` message — it executes them; use `jj describe --stdin < file` for any message containing them.
+- One commit per task is fine *while implementing this plan* (they are review checkpoints). Squash before opening a PR; the repo ships one commit per PR.
+
+---
+
+## File Structure
+
+| File | Responsibility after this plan |
+|---|---|
+| `crates/tt-core/src/allocation.rs` (modify, 2,490 lines) | Owns the allocation rules. Gains `Allocator` (`new`/`push`/`finish`); `allocate_time` becomes a thin wrapper over it. No rule changes. |
+| `crates/tt-db/src/lib.rs` (modify, ~10,400 lines) | Gains `event_time_bounds`, `sessions_spanning_multiple_streams`, `sessions_with_tool_use_but_no_start`, `for_each_event_in_range`. `allocate_for_period` rewritten to stream into `Allocator`. |
+| `crates/tt-cli/src/commands/recompute.rs` (modify, 478 lines) | Stops loading the full history. Uses the two new aggregate queries. |
+| `AGENTS.md` (modify) | Records the measured before/after and the rule that allocation must never re-materialize the history. |
+
+`allocation.rs` is already far over any size ceiling and is the house pattern for this repo (`tt-db/src/lib.rs` is 10k lines). Do **not** split it as part of this plan; that is a separate change with its own review.
+
+---
+
+### Task 1: Stop `recompute` loading the whole history
+
+`crates/tt-cli/src/commands/recompute.rs:68` calls `db.get_events(None, None)`, materializing all 2,738,805 events. That Vec is used for exactly three things: a warning about sessions split across streams, `earliest`, and `latest`. Then `allocate_for_period` loads every event **again**. This task deletes the first copy.
+
+**Files:**
+- Modify: `crates/tt-db/src/lib.rs` (add two methods near `get_events_in_range`, line ~1472)
+- Modify: `crates/tt-cli/src/commands/recompute.rs:50-120`
+- Test: `crates/tt-db/src/lib.rs` (`mod tests`), `crates/tt-cli/src/commands/recompute.rs` (`mod tests`)
+
+**Interfaces:**
+- Produces:
+  - `Database::event_time_bounds(&self) -> Result<Option<(DateTime<Utc>, DateTime<Utc>)>, DbError>` — `None` when the table is empty.
+  - `Database::sessions_spanning_multiple_streams(&self) -> Result<Vec<(String, Vec<String>)>, DbError>` — session id → its distinct stream ids, only sessions with 2+, ordered by session id, each inner list ordered.
+
+- [ ] **Step 1: Write the failing test for `event_time_bounds`**
+
+Add to `crates/tt-db/src/lib.rs` inside `mod tests`:
+
+```rust
+    #[test]
+    fn event_time_bounds_reports_the_first_and_last_event() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(db.event_time_bounds().unwrap(), None);
+
+        db.insert_events(&[
+            make_event("b", Utc.with_ymd_and_hms(2026, 3, 2, 9, 0, 0).unwrap(), EventType::UserMessage),
+            make_event("a", Utc.with_ymd_and_hms(2026, 3, 1, 9, 0, 0).unwrap(), EventType::UserMessage),
+            make_event("c", Utc.with_ymd_and_hms(2026, 3, 3, 9, 0, 0).unwrap(), EventType::UserMessage),
+        ])
+        .unwrap();
+
+        let (first, last) = db.event_time_bounds().unwrap().unwrap();
+        assert_eq!(first, Utc.with_ymd_and_hms(2026, 3, 1, 9, 0, 0).unwrap());
+        assert_eq!(last, Utc.with_ymd_and_hms(2026, 3, 3, 9, 0, 0).unwrap());
+    }
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cargo test -p tt-db --lib event_time_bounds_reports_the_first_and_last_event`
+Expected: compile error — `no method named 'event_time_bounds' found`.
+
+- [ ] **Step 3: Implement `event_time_bounds`**
+
+Add to `impl Database` in `crates/tt-db/src/lib.rs`, immediately after `get_events_in_range`:
+
+```rust
+    /// The timestamps of the first and last event, or `None` when there are none.
+    ///
+    /// Answers in one aggregate what `recompute` used to answer by materializing every
+    /// event and reading `.first()` and `.last()`. Measured on the live 2.2 GB corpus,
+    /// that load cost 8.9 GB of RSS to produce two timestamps.
+    pub fn event_time_bounds(&self) -> Result<Option<(DateTime<Utc>, DateTime<Utc>)>, DbError> {
+        let row: Option<(Option<String>, Option<String>)> = self
+            .conn
+            .query_row("SELECT MIN(timestamp), MAX(timestamp) FROM events", [], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .optional()?;
+        let Some((Some(first), Some(last))) = row else {
+            return Ok(None);
+        };
+        Ok(Some((
+            parse_event_bound("MIN(timestamp)", &first)?,
+            parse_event_bound("MAX(timestamp)", &last)?,
+        )))
+    }
+```
+
+There is **no** general `parse_timestamp` in this crate, so add a free function and a sibling error type next to the existing `MalformedStreamTimestamp` (`crates/tt-db/src/lib.rs:206`), matching `parse_stream_timestamp` (line 258) exactly in posture — an unreadable timestamp is an **error naming the offending text**, never a substituted `Utc::now()` (see `crates/tt-db/AGENTS.md`, "A timestamp that cannot be read is an error, never a substitution"):
+
+```rust
+/// Carries the column and the offending text, because the point of failing here is that a
+/// person can go look at the row.
+#[derive(Debug, Error)]
+#[error("events has an unreadable {column} timestamp {value:?}: {source}")]
+struct MalformedEventBound {
+    column: &'static str,
+    value: String,
+    source: chrono::ParseError,
+}
+
+fn parse_event_bound(column: &'static str, value: &str) -> Result<DateTime<Utc>, rusqlite::Error> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|source| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(MalformedEventBound {
+                    column,
+                    value: value.to_string(),
+                    source,
+                }),
+            )
+        })
+}
+```
+
+`rusqlite::Error` converts into `DbError` through the existing `#[from]` on `DbError::Sqlite`, so the `?` in `event_time_bounds` needs nothing further.
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `cargo test -p tt-db --lib event_time_bounds_reports_the_first_and_last_event`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Write the failing test for `sessions_spanning_multiple_streams`**
+
+```rust
+    #[test]
+    fn sessions_spanning_multiple_streams_reports_only_the_split_ones() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_stream(&make_test_stream("stream-a", "A")).unwrap();
+        db.insert_stream(&make_test_stream("stream-b", "B")).unwrap();
+
+        let mut split_one = make_event("e1", Utc.with_ymd_and_hms(2026, 3, 1, 9, 0, 0).unwrap(), EventType::UserMessage);
+        split_one.session_id = Some("split".to_string());
+        split_one.stream_id = Some("stream-a".to_string());
+        let mut split_two = make_event("e2", Utc.with_ymd_and_hms(2026, 3, 1, 9, 1, 0).unwrap(), EventType::UserMessage);
+        split_two.session_id = Some("split".to_string());
+        split_two.stream_id = Some("stream-b".to_string());
+        let mut settled = make_event("e3", Utc.with_ymd_and_hms(2026, 3, 1, 9, 2, 0).unwrap(), EventType::UserMessage);
+        settled.session_id = Some("settled".to_string());
+        settled.stream_id = Some("stream-a".to_string());
+        db.insert_events(&[split_one, split_two, settled]).unwrap();
+
+        assert_eq!(
+            db.sessions_spanning_multiple_streams().unwrap(),
+            vec![("split".to_string(), vec!["stream-a".to_string(), "stream-b".to_string()])]
+        );
+    }
+```
+
+- [ ] **Step 6: Run it and confirm it fails**
+
+Run: `cargo test -p tt-db --lib sessions_spanning_multiple_streams_reports_only_the_split_ones`
+Expected: compile error — method not found.
+
+- [ ] **Step 7: Implement `sessions_spanning_multiple_streams`**
+
+```rust
+    /// Sessions whose events point at more than one stream, with those streams.
+    ///
+    /// A data-integrity report `recompute` prints, and it never needed the events in
+    /// memory to produce it. Ordered by session id, and each stream list ordered, so the
+    /// warning block is stable between runs.
+    pub fn sessions_spanning_multiple_streams(
+        &self,
+    ) -> Result<Vec<(String, Vec<String>)>, DbError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT session_id, stream_id FROM events
+             WHERE session_id IS NOT NULL AND stream_id IS NOT NULL
+               AND session_id IN (
+                   SELECT session_id FROM events
+                   WHERE session_id IS NOT NULL AND stream_id IS NOT NULL
+                   GROUP BY session_id
+                   HAVING COUNT(DISTINCT stream_id) > 1
+               )
+             GROUP BY session_id, stream_id
+             ORDER BY session_id ASC, stream_id ASC",
+        )?;
+        let mut grouped: Vec<(String, Vec<String>)> = Vec::new();
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let session_id: String = row.get(0)?;
+            let stream_id: String = row.get(1)?;
+            match grouped.last_mut() {
+                Some((existing, streams)) if *existing == session_id => streams.push(stream_id),
+                _ => grouped.push((session_id, vec![stream_id])),
+            }
+        }
+        Ok(grouped)
+    }
+```
+
+- [ ] **Step 8: Run it and confirm it passes**
+
+Run: `cargo test -p tt-db --lib sessions_spanning_multiple_streams_reports_only_the_split_ones`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 9: Rewrite `recompute::run` to use them**
+
+In `crates/tt-cli/src/commands/recompute.rs`, delete the `let events = db.get_events(None, None)...` block, the `session_streams` `HashMap` build, and the `earliest`/`latest` lines derived from `events`. Replace that whole region (currently lines ~66–117) with:
+
+```rust
+    // Bounds and the split-session warning are aggregates. Loading every event to derive
+    // them cost 8.9 GB of RSS on the live corpus, and `allocate_for_period` loads the
+    // events it needs itself.
+    let Some((earliest, latest)) = db
+        .event_time_bounds()
+        .context("failed to read event time bounds")?
+    else {
+        println!("No events to process.");
+        return Ok(());
+    };
+
+    // Sessions split across streams undercount, so they are reported. Not fatal: only the
+    // user can say which stream such a session belongs to.
+    for (session_id, stream_ids) in db
+        .sessions_spanning_multiple_streams()
+        .context("failed to check for sessions split across streams")?
+    {
+        let shown = &session_id[..session_id.len().min(30)];
+        eprintln!(
+            "Warning: session {} has events in {} streams: {:?}",
+            shown,
+            stream_ids.len(),
+            stream_ids,
+        );
+        eprintln!("  Use 'tt streams assign <stream-ref> --session {shown}' to settle it.");
+    }
+```
+
+Keep the `let config = AllocationConfig::default();` and the `allocate_for_period(db, earliest, latest + Duration::milliseconds(1), None, &config)` call exactly as they are. Remove the now-unused `use std::collections::HashMap;` if nothing else in the file uses it, and remove the `tracing::debug!(event_count = ...)` line that referenced `events`.
+
+- [ ] **Step 10: Verify the whole suite and the lints**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, **zero** clippy warnings, all tests pass (baseline is 1,154 passing).
+
+- [ ] **Step 11: Verify the numbers did not move, and measure the win**
+
+```bash
+cp ~/.local/share/time-tracker/tt.db /tmp/t1.db
+cargo build --release --bin tt
+TT_DATABASE_PATH=/tmp/t1.db ./target/release/tt report --start 2026-07-20 --end 2026-07-21 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/t1.db ./target/release/tt report --start 2026-07-13 --end 2026-07-20 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/t1.db /usr/bin/time -f 'wall=%es cpu=%P peak_rss=%MKB' ./target/release/tt recompute | tail -3
+```
+
+Expected: `Direct time: 16h 23m` and `Direct time: 74h 20m` (unchanged). `peak_rss` roughly halved from 8,928,316 KB, because one of the two full copies is gone. Record the actual figure — the next task is measured against it.
+
+- [ ] **Step 12: Commit**
+
+```bash
+jj describe -m "perf(recompute): derive bounds and split-session warning by aggregate
+
+recompute loaded all 2,738,805 events to compute a MIN, a MAX, and a
+group-by, then allocate_for_period loaded every event again. Two full
+copies of the history, 8.9 GB peak RSS, to produce two timestamps and a
+warning. Both are now single aggregate queries."
+jj new
+```
+
+---
+
+### Task 2: Expose the existing pass as an incremental `Allocator`
+
+`allocate_time` (`crates/tt-core/src/allocation.rs:195`) is already a single forward pass: the event loop is `for event in events` at line 242 and runs to roughly line 660; finalization (`final_attributions`, the per-stream union, the `AllocationResult` literal) runs from line 662 to about line 720. Nothing indexes or re-reads the slice. This task is a **pure refactor** that turns that pass into a struct you can feed one event at a time. No rule changes, no test edits.
+
+**Files:**
+- Modify: `crates/tt-core/src/allocation.rs:195-720`
+- Test: `crates/tt-core/src/allocation.rs` (`mod tests`) — existing 55 tests must pass untouched, plus one new equivalence test.
+
+**Interfaces:**
+- Produces:
+  - `pub struct Allocator<'a>` holding every `let mut` currently local to `allocate_time` (`focus_state`, `window_focus_state`, `browser_focus_state`, `tmux_focus_stream_id`, `agent_sessions`, `stream_times`, `activity_intervals`, `last_event_time`) plus borrows of `config: &'a AllocationConfig`, `session_end_times: &'a HashMap<String, DateTime<Utc>>`, `session_types: &'a HashMap<String, SessionType>`, and `period_end: Option<DateTime<Utc>>`.
+  - `Allocator::new(config: &'a AllocationConfig, period_end: Option<DateTime<Utc>>, session_end_times: &'a HashMap<String, DateTime<Utc>>, session_types: &'a HashMap<String, SessionType>) -> Self`
+  - `Allocator::push<E: AllocatableEvent>(&mut self, event: &E)`
+  - `Allocator::finish(self) -> AllocationResult`
+- Consumes: nothing from Task 1.
+
+- [ ] **Step 1: Write the equivalence test first**
+
+Add to `mod tests` in `crates/tt-core/src/allocation.rs`. It pins that feeding events one at a time is identical to passing the slice — the property every later task depends on:
+
+```rust
+    #[test]
+    fn pushing_events_one_at_a_time_equals_allocating_the_whole_slice() {
+        // Given: a corpus exercising focus, agent work, and an unassigned stretch.
+        let events = vec![
+            make_focus_event("f1", ts(2026, 3, 1, 9, 0, 0), Some("stream-a")),
+            make_agent_event("s1", ts(2026, 3, 1, 9, 1, 0), "session-1", "started", Some("stream-a")),
+            make_tool_event("t1", ts(2026, 3, 1, 9, 2, 0), "session-1", Some("stream-a")),
+            make_tool_event("t2", ts(2026, 3, 1, 9, 30, 0), "session-1", Some("stream-a")),
+            make_focus_event("f2", ts(2026, 3, 1, 10, 0, 0), None),
+            make_agent_event("s2", ts(2026, 3, 1, 10, 1, 0), "session-1", "ended", Some("stream-a")),
+        ];
+        let config = AllocationConfig::default();
+        let end_times = HashMap::new();
+        let types = HashMap::new();
+
+        // When: the slice path and the incremental path both run.
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "this test exists to compare the two entry points directly"
+        )]
+        let from_slice = allocate_time(&events, &config, None, &end_times, &types);
+        let mut allocator = Allocator::new(&config, None, &end_times, &types);
+        for event in &events {
+            allocator.push(event);
+        }
+        let from_pushes = allocator.finish();
+
+        // Then: identical in every field, not merely in the totals.
+        assert_eq!(from_pushes.total_tracked_ms, from_slice.total_tracked_ms);
+        assert_eq!(from_pushes.unassigned_direct_ms, from_slice.unassigned_direct_ms);
+        assert_eq!(from_pushes.unassigned_delegated_ms, from_slice.unassigned_delegated_ms);
+        let mut pushed = from_pushes.stream_times;
+        let mut sliced = from_slice.stream_times;
+        pushed.sort_by(|a, b| a.stream_id.cmp(&b.stream_id));
+        sliced.sort_by(|a, b| a.stream_id.cmp(&b.stream_id));
+        assert_eq!(pushed.len(), sliced.len());
+        for (p, s) in pushed.iter().zip(sliced.iter()) {
+            assert_eq!(p.stream_id, s.stream_id);
+            assert_eq!(p.time_direct_ms, s.time_direct_ms, "direct for {}", p.stream_id);
+            assert_eq!(p.time_delegated_ms, s.time_delegated_ms, "delegated for {}", p.stream_id);
+        }
+    }
+```
+
+Use whatever fixture builders already exist in that `mod tests` for focus, agent-session, and tool-use events — read the existing tests around `allocation.rs:1173` (`test_concurrent_agents`) and reuse their helpers rather than adding new ones. If the helpers are named differently from `make_focus_event` / `make_agent_event` / `make_tool_event` / `ts`, use the real names; do not add duplicates.
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cargo test -p tt-core --lib pushing_events_one_at_a_time_equals_allocating_the_whole_slice`
+Expected: compile error — `cannot find struct 'Allocator'`.
+
+- [ ] **Step 3: Declare the struct and `new`**
+
+Insert immediately before `pub fn allocate_time` in `crates/tt-core/src/allocation.rs`:
+
+```rust
+/// The allocation pass, fed one event at a time.
+///
+/// [`allocate_time`] has always been a single forward walk over timestamp-sorted events
+/// with its state in maps — it never indexed the slice or looked backwards. Taking
+/// `&[E]` was therefore a property of the signature and not of the algorithm, and it was
+/// an expensive one: `tt recompute` held all 2,738,805 events to run it, peaking at
+/// 8.9 GB where the equivalent SQLite aggregate uses 6.4 MB.
+///
+/// Splitting the walk from its input lets a caller stream rows straight from SQLite.
+/// Memory becomes a function of concurrently-open sessions, streams, and recorded
+/// intervals rather than of history length.
+///
+/// Events must still arrive in ascending timestamp order. That requirement is the
+/// algorithm's, not the container's, and pushing them out of order silently produces
+/// wrong time exactly as passing an unsorted slice always did.
+pub struct Allocator<'a> {
+    config: &'a AllocationConfig,
+    period_end: Option<DateTime<Utc>>,
+    session_end_times: &'a HashMap<String, DateTime<Utc>>,
+    session_types: &'a HashMap<String, SessionType>,
+    focus_state: FocusState,
+    window_focus_state: WindowFocusState,
+    browser_focus_state: BrowserFocusState,
+    tmux_focus_stream_id: Option<String>,
+    agent_sessions: HashMap<String, AgentSession>,
+    stream_times: HashMap<String, StreamAllocation>,
+    activity_intervals: Vec<Interval>,
+    last_event_time: Option<DateTime<Utc>>,
+}
+
+impl<'a> Allocator<'a> {
+    /// Starts a pass with no events seen yet.
+    #[must_use]
+    pub fn new(
+        config: &'a AllocationConfig,
+        period_end: Option<DateTime<Utc>>,
+        session_end_times: &'a HashMap<String, DateTime<Utc>>,
+        session_types: &'a HashMap<String, SessionType>,
+    ) -> Self {
+        Self {
+            config,
+            period_end,
+            session_end_times,
+            session_types,
+            focus_state: FocusState::Unfocused,
+            window_focus_state: WindowFocusState::default(),
+            browser_focus_state: BrowserFocusState::default(),
+            tmux_focus_stream_id: None,
+            agent_sessions: HashMap::new(),
+            stream_times: HashMap::new(),
+            activity_intervals: Vec::new(),
+            last_event_time: None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Move the loop body into `push`**
+
+Add `pub fn push<E: AllocatableEvent>(&mut self, event: &E)` to that `impl`, and move the **body of the `for event in events` loop** (`allocation.rs` line ~243 through the loop's closing brace, ~line 660) into it verbatim. Then make it compile by mechanical substitution only:
+
+- Every bare local becomes a field: `focus_state` → `self.focus_state`, `agent_sessions` → `self.agent_sessions`, `stream_times` → `self.stream_times`, `activity_intervals` → `self.activity_intervals`, `last_event_time` → `self.last_event_time`, `tmux_focus_stream_id` → `self.tmux_focus_stream_id`, `window_focus_state` → `self.window_focus_state`, `browser_focus_state` → `self.browser_focus_state`, `config` → `self.config`, `period_end` → `self.period_end`, `session_end_times` → `self.session_end_times`, `session_types` → `self.session_types`.
+- The `add_direct` closure (line ~213) closes over nothing but its arguments, so lift it to a **private associated function** rather than a field:
+
+```rust
+    fn add_direct(
+        stream_id: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        intervals: &mut Vec<Interval>,
+        times: &mut HashMap<String, StreamAllocation>,
+    ) {
+        if end > start {
+            let interval = Interval { start, end };
+            let allocation = times.entry(stream_id.to_string()).or_default();
+            allocation.focus_intervals.push(interval);
+            intervals.push(interval);
+        }
+    }
+```
+
+Call sites become `Self::add_direct(stream_id, start, end, &mut self.activity_intervals, &mut self.stream_times)`. Do the same for any other closure defined between lines 202 and 242 — check for them; there may be more than one.
+
+**Change no conditions, no arithmetic, no ordering, and no `EventType` arm.** If borrow-checker errors appear because a statement holds `&self.x` while mutating `self.y`, bind locals first (`let config = self.config;`) rather than restructuring logic.
+
+- [ ] **Step 5: Move finalization into `finish`**
+
+Add `pub fn finish(self) -> AllocationResult` and move `allocation.rs` lines ~662 to ~720 into it verbatim — the `final_attributions` block, the `for (stream_id, first_tool, session_end)` loop, the per-stream union, and the `AllocationResult { ... }` literal. Apply the same `self.` substitution. Nothing else moves.
+
+- [ ] **Step 6: Reduce `allocate_time` to a wrapper**
+
+Replace the whole body of `pub fn allocate_time` with:
+
+```rust
+) -> AllocationResult {
+    let mut allocator = Allocator::new(config, period_end, session_end_times, session_types);
+    for event in events {
+        allocator.push(event);
+    }
+    allocator.finish()
+}
+```
+
+Keep its signature, its doc comment, and its `clippy.toml` `disallowed-methods` entry exactly as they are. Existing callers and every existing test keep working through it unchanged.
+
+- [ ] **Step 7: Run the full allocation suite unmodified**
+
+Run: `cargo test -p tt-core --lib allocation`
+Expected: all 56 tests pass (the 55 existing plus the new equivalence test), **with no edits to any existing test**. Confirm by name that these three passed:
+- `test_total_direct_time_never_exceeds_wall_clock`
+- `test_parallel_agent_sessions_sum_delegated_beyond_wall_clock`
+- `a_sessions_delegated_span_never_outruns_the_end_event_that_closed_it`
+
+If any existing test required a change to pass, revert and find what the move altered.
+
+- [ ] **Step 8: Full gates**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, 1,155 tests passing.
+
+- [ ] **Step 9: Verify the reported numbers are still identical**
+
+```bash
+cp ~/.local/share/time-tracker/tt.db /tmp/t2.db
+cargo build --release --bin tt
+TT_DATABASE_PATH=/tmp/t2.db ./target/release/tt report --start 2026-07-20 --end 2026-07-21 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/t2.db ./target/release/tt report --start 2026-07-13 --end 2026-07-20 | grep '^Direct time:'
+```
+
+Expected: `Direct time: 16h 23m`, `Direct time: 74h 20m`. This task is a pure refactor; anything else means the move changed behavior.
+
+- [ ] **Step 10: Commit**
+
+```bash
+jj describe -m "refactor(allocation): expose the pass as an incremental Allocator
+
+allocate_time was already a single forward walk with its state in maps; it
+held the whole history only because it took a slice. Allocator::push and
+::finish are that same walk, fed one event at a time. allocate_time is now
+a wrapper over it, so every caller and all 55 existing tests are untouched."
+jj new
+```
+
+---
+
+### Task 3: Stream events from SQLite into the `Allocator`
+
+`allocate_for_period` (`crates/tt-db/src/lib.rs:4633`) calls `get_events_in_range`, materializing every event in the window — the second of the two full copies. This task feeds the `Allocator` row by row instead, and replaces the in-memory pre-pass that finds sessions with tool use but no `started` event with a query.
+
+**Files:**
+- Modify: `crates/tt-db/src/lib.rs` (add two methods near line 1472; rewrite `allocate_for_period` at 4633)
+- Test: `crates/tt-db/src/lib.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `tt_core::allocation::Allocator::{new, push, finish}` from Task 2.
+- Produces:
+  - `Database::for_each_event_in_range<F>(&self, start: DateTime<Utc>, end: DateTime<Utc>, f: F) -> Result<(), DbError> where F: FnMut(StoredEvent)`
+  - `Database::sessions_with_tool_use_but_no_start(&self, start: DateTime<Utc>, end: DateTime<Utc>) -> Result<Vec<String>, DbError>` — ordered ascending, distinct.
+
+- [ ] **Step 1: Write the failing test for streaming reads**
+
+```rust
+    #[test]
+    fn for_each_event_in_range_visits_rows_in_timestamp_order_without_collecting() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_events(&[
+            make_event("b", Utc.with_ymd_and_hms(2026, 3, 1, 9, 1, 0).unwrap(), EventType::UserMessage),
+            make_event("a", Utc.with_ymd_and_hms(2026, 3, 1, 9, 0, 0).unwrap(), EventType::UserMessage),
+            make_event("c", Utc.with_ymd_and_hms(2026, 3, 1, 9, 2, 0).unwrap(), EventType::UserMessage),
+            make_event("outside", Utc.with_ymd_and_hms(2026, 4, 1, 9, 0, 0).unwrap(), EventType::UserMessage),
+        ])
+        .unwrap();
+
+        let mut seen = Vec::new();
+        db.for_each_event_in_range(
+            Utc.with_ymd_and_hms(2026, 3, 1, 9, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 3, 1, 9, 2, 0).unwrap(),
+            |event| seen.push(event.id),
+        )
+        .unwrap();
+
+        assert_eq!(seen, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cargo test -p tt-db --lib for_each_event_in_range_visits_rows_in_timestamp_order_without_collecting`
+Expected: compile error — method not found.
+
+- [ ] **Step 3: Implement `for_each_event_in_range`**
+
+Mirror `get_events_in_range` (line 1472) exactly, but hand each row to the callback instead of pushing it into a `Vec`:
+
+```rust
+    /// Visits every event in `start..=end`, in ascending timestamp order.
+    ///
+    /// The streaming counterpart of [`Self::get_events_in_range`], which returns a `Vec`
+    /// and therefore holds the whole window: on the live corpus that was 2,738,805 rows
+    /// and the larger half of `tt recompute`'s 8.9 GB. The allocation pass only ever
+    /// walks forward, so it never needed the `Vec`.
+    ///
+    /// Rows that cannot be read are skipped, matching `get_events_in_range`.
+    pub fn for_each_event_in_range<F>(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        mut f: F,
+    ) -> Result<(), DbError>
+    where
+        F: FnMut(StoredEvent),
+    {
+        let sql = format!(
+            "SELECT {EVENT_COLUMNS} FROM events
+             WHERE timestamp >= ?1 AND timestamp <= ?2
+             ORDER BY timestamp ASC"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = stmt.query(params![format_timestamp(start), format_timestamp(end)])?;
+        while let Some(row) = rows.next()? {
+            if let Some(event) = Self::row_to_event(row)? {
+                f(event);
+            }
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `cargo test -p tt-db --lib for_each_event_in_range_visits_rows_in_timestamp_order_without_collecting`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Write the failing test for the missing-start query**
+
+```rust
+    #[test]
+    fn sessions_with_tool_use_but_no_start_finds_only_the_unstarted() {
+        let db = Database::open_in_memory().unwrap();
+        let window_start = Utc.with_ymd_and_hms(2026, 3, 1, 0, 0, 0).unwrap();
+        let window_end = Utc.with_ymd_and_hms(2026, 3, 2, 0, 0, 0).unwrap();
+
+        let mut started = make_event("s", Utc.with_ymd_and_hms(2026, 3, 1, 9, 0, 0).unwrap(), EventType::AgentSession);
+        started.session_id = Some("has-start".to_string());
+        started.action = Some("started".to_string());
+        let mut tool_with = make_event("t1", Utc.with_ymd_and_hms(2026, 3, 1, 9, 1, 0).unwrap(), EventType::AgentToolUse);
+        tool_with.session_id = Some("has-start".to_string());
+        let mut tool_without = make_event("t2", Utc.with_ymd_and_hms(2026, 3, 1, 9, 2, 0).unwrap(), EventType::AgentToolUse);
+        tool_without.session_id = Some("no-start".to_string());
+        db.insert_events(&[started, tool_with, tool_without]).unwrap();
+
+        assert_eq!(
+            db.sessions_with_tool_use_but_no_start(window_start, window_end).unwrap(),
+            vec!["no-start".to_string()]
+        );
+    }
+```
+
+- [ ] **Step 6: Run it and confirm it fails**
+
+Run: `cargo test -p tt-db --lib sessions_with_tool_use_but_no_start_finds_only_the_unstarted`
+Expected: compile error — method not found.
+
+- [ ] **Step 7: Implement `sessions_with_tool_use_but_no_start`**
+
+This must reproduce, in SQL, exactly what `allocate_for_period` currently computes at lines 4647–4663: session ids of `agent_tool_use` events in the window whose session has no `agent_session`/`started` event in that same window.
+
+```rust
+    /// Sessions with agent tool use in the window but no `started` event in it.
+    ///
+    /// The query form of the pre-pass `allocate_for_period` used to run over a
+    /// materialized `Vec` of every event in the window. Same window, same predicate: a
+    /// session whose start fell outside the range needs its start event fetched, or its
+    /// delegated span has no opening.
+    pub fn sessions_with_tool_use_but_no_start(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<String>, DbError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT DISTINCT t.session_id FROM events t
+             WHERE t.type = 'agent_tool_use'
+               AND t.session_id IS NOT NULL
+               AND t.timestamp >= ?1 AND t.timestamp <= ?2
+               AND NOT EXISTS (
+                   SELECT 1 FROM events s
+                   WHERE s.type = 'agent_session' AND s.action = 'started'
+                     AND s.session_id = t.session_id
+                     AND s.timestamp >= ?1 AND s.timestamp <= ?2
+               )
+             ORDER BY t.session_id ASC",
+        )?;
+        let rows = stmt.query_map(
+            params![format_timestamp(start), format_timestamp(end)],
+            |row| row.get::<_, String>(0),
+        )?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(DbError::from)
+    }
+```
+
+Confirm the stored discriminants for `EventType::AgentToolUse` and `EventType::AgentSession` really are the strings `'agent_tool_use'` and `'agent_session'` by checking how `insert_events` serializes `event_type` — if they differ, use the real values.
+
+- [ ] **Step 8: Run it and confirm it passes**
+
+Run: `cargo test -p tt-db --lib sessions_with_tool_use_but_no_start_finds_only_the_unstarted`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 9: Rewrite `allocate_for_period` to stream**
+
+Replace lines 4640–4669 of `crates/tt-db/src/lib.rs` (the `get_events_in_range` load, the two `BTreeSet`/`Vec` pre-passes, and the `start_events.append(&mut events)` splice) so that the function builds the maps first, then streams. Keep everything after the current line 4671 (`agent_sessions_in_range` onward) — including how `session_types` and `session_end_times` are built — unchanged, and keep feeding `Allocator` in the **same order** the old code produced: fetched start events first, then the window's events in timestamp order.
+
+```rust
+    let inclusive_end = end - chrono::Duration::milliseconds(1);
+    if inclusive_end < start {
+        let agent_sessions = db.agent_sessions_in_range(start, end)?;
+        // ... build session_types / session_end_times exactly as below, then:
+        let allocator = tt_core::allocation::Allocator::new(
+            config,
+            period_end,
+            &session_end_times,
+            &session_types,
+        );
+        return Ok(allocator.finish());
+    }
+```
+
+then, for the normal path, after `session_types` and `session_end_times` are built:
+
+```rust
+    let mut allocator =
+        tt_core::allocation::Allocator::new(config, period_end, &session_end_times, &session_types);
+
+    // Start events for sessions whose opening fell outside the window are pushed first,
+    // exactly as the old code prepended them to the Vec.
+    let missing_session_ids = db.sessions_with_tool_use_but_no_start(start, inclusive_end)?;
+    if !missing_session_ids.is_empty() {
+        for event in db.get_agent_session_start_events(&missing_session_ids)? {
+            allocator.push(&event);
+        }
+    }
+
+    // Then the window itself, streamed in timestamp order: one row is resident at a time
+    // instead of all 2.7M.
+    db.for_each_event_in_range(start, inclusive_end, |event| allocator.push(&event))?;
+
+    Ok(allocator.finish())
+```
+
+The `#[expect(clippy::disallowed_methods, ...)]` currently on this function's call to `allocate_time` is no longer needed if the call is gone — remove it, and add `tt_core::allocation::Allocator::push` to `clippy.toml`'s `disallowed-methods` **only if** the team wants the same gate on the new entry point; default is to leave `clippy.toml` alone, since `allocate_for_period` remains the single public path.
+
+- [ ] **Step 10: Full gates plus every allocation test**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass. The tests in `crates/tt-cli/tests/` that exercise reports and recompute end-to-end are the real check here — they compare full outputs.
+
+- [ ] **Step 11: Verify numbers and measure the win**
+
+```bash
+cp ~/.local/share/time-tracker/tt.db /tmp/t3.db
+cargo build --release --bin tt
+TT_DATABASE_PATH=/tmp/t3.db ./target/release/tt report --start 2026-07-20 --end 2026-07-21 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/t3.db ./target/release/tt report --start 2026-07-13 --end 2026-07-20 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/t3.db /usr/bin/time -f 'wall=%es cpu=%P peak_rss=%MKB' ./target/release/tt recompute | tail -3
+```
+
+Expected: `Direct time: 16h 23m` and `Direct time: 74h 20m` still. `peak_rss` now dominated by recorded intervals and per-stream state rather than events — target well under 1 GB against the 8.9 GB baseline. Record the figure.
+
+- [ ] **Step 12: Commit**
+
+```bash
+jj describe -m "perf(allocation): stream events instead of materializing the window
+
+allocate_for_period loaded every event in the range into a Vec and ran two
+in-memory pre-passes over it. It now streams rows into Allocator::push and
+answers the missing-start question with a query. Same order in, same
+numbers out; resident set no longer scales with history length."
+jj new
+```
+
+---
+
+### Task 4: Parallelize the per-stream union
+
+`finish` unions each stream's `focus_intervals` to get `time_direct_ms`. Streams are independent of one another, so this is the one genuinely CPU-bound, embarrassingly parallel part of the pass — and it currently runs on one of 24 cores. `rayon` is already a `tt-core` dependency (`crates/tt-core/Cargo.toml:15`) and already used in `session.rs:624` and `opencode.rs:219`.
+
+**Files:**
+- Modify: `crates/tt-core/src/allocation.rs` (`Allocator::finish`)
+- Test: `crates/tt-core/src/allocation.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `Allocator::finish` from Task 2.
+- Produces: no signature change. `finish` keeps returning `AllocationResult`.
+
+- [ ] **Step 1: Write the failing test — determinism under parallelism**
+
+Parallel iteration must not reorder or perturb results. This test pins that many streams come back with identical, deterministically ordered totals:
+
+```rust
+    #[test]
+    fn many_streams_union_identically_however_the_work_is_scheduled() {
+        // Given: enough streams that rayon will actually split the work.
+        let mut events = Vec::new();
+        for stream in 0..64 {
+            let stream_id = format!("stream-{stream:02}");
+            for minute in 0..8 {
+                events.push(make_focus_event(
+                    &format!("f-{stream:02}-{minute}"),
+                    ts(2026, 3, 1, 9, minute * 2, 0),
+                    Some(&stream_id),
+                ));
+            }
+        }
+        let config = AllocationConfig::default();
+        let end_times = HashMap::new();
+        let types = HashMap::new();
+
+        // When: the same corpus is allocated twice.
+        let run = || {
+            let mut allocator = Allocator::new(&config, None, &end_times, &types);
+            for event in &events {
+                allocator.push(event);
+            }
+            let mut times = allocator.finish().stream_times;
+            times.sort_by(|a, b| a.stream_id.cmp(&b.stream_id));
+            times
+        };
+        let first = run();
+        let second = run();
+
+        // Then: byte-identical, and every stream present.
+        assert_eq!(first.len(), 64);
+        for (a, b) in first.iter().zip(second.iter()) {
+            assert_eq!(a.stream_id, b.stream_id);
+            assert_eq!(a.time_direct_ms, b.time_direct_ms);
+            assert_eq!(a.time_delegated_ms, b.time_delegated_ms);
+        }
+    }
+```
+
+- [ ] **Step 2: Run it and confirm it passes already**
+
+Run: `cargo test -p tt-core --lib many_streams_union_identically_however_the_work_is_scheduled`
+Expected: PASS. This one is a guard written *before* the optimization so it can catch a regression the optimization might introduce — it is not expected to fail first. Note that explicitly in the commit message.
+
+- [ ] **Step 3: Parallelize the union inside `finish`**
+
+In `Allocator::finish`, the finalization currently reads (`crates/tt-core/src/allocation.rs:695-718`):
+
+```rust
+    // Calculate total tracked time from interval union
+    let total_tracked_ms = union_duration_ms(&activity_intervals);
+
+    let unassigned = stream_times
+        .remove(UNASSIGNED_STREAM_ID)
+        .unwrap_or_default();
+
+    let stream_times_vec = stream_times
+        .into_iter()
+        .map(|(stream_id, allocation)| StreamTime {
+            stream_id,
+            time_direct_ms: union_duration_ms(&allocation.focus_intervals),
+            time_delegated_ms: allocation.delegated_ms,
+            focus_intervals: allocation.focus_intervals,
+            delegated_intervals: allocation.delegated_intervals,
+        })
+        .collect();
+```
+
+Replace only the `stream_times_vec` binding with a parallel map, then sort:
+
+```rust
+    let mut stream_times_vec: Vec<StreamTime> = self
+        .stream_times
+        .into_iter()
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|(stream_id, allocation)| StreamTime {
+            stream_id,
+            time_direct_ms: union_duration_ms(&allocation.focus_intervals),
+            time_delegated_ms: allocation.delegated_ms,
+            focus_intervals: allocation.focus_intervals,
+            delegated_intervals: allocation.delegated_intervals,
+        })
+        .collect();
+    // Sorted so output order does not depend on how rayon scheduled the work; the previous
+    // `HashMap` iteration order was already unspecified, and parallel collection makes that
+    // worse rather than different.
+    stream_times_vec.sort_by(|a, b| a.stream_id.cmp(&b.stream_id));
+```
+
+Add `use rayon::prelude::*;` at the top of `allocation.rs` (it is already a `tt-core` dependency and already imported this way in `session.rs:8`).
+
+**Three things must not move.** The `stream_times.remove(UNASSIGNED_STREAM_ID)` **has to stay before** this map: `UNASSIGNED_STREAM_ID` (`allocation.rs:21`) is the synthetic `"(unassigned)"` bucket that unattributed events accrue into, and the doc contract at line 179 is that the sentinel is removed from `stream_times` before returning. Parallelizing before removing it would publish `(unassigned)` as a real stream row and double-count it in every report. `total_tracked_ms` stays a union of `activity_intervals`. And `time_delegated_ms` stays `allocation.delegated_ms` — **a sum across concurrent sessions, never a union**; `test_parallel_agent_sessions_sum_delegated_beyond_wall_clock` (line 2402) fails if that changes.
+
+If the existing code did not sort `stream_times`, adding the sort is still correct and required — parallel collection makes the previous `HashMap` iteration order even less defined than it was. Check whether any insta snapshot depends on that order; if one does, run `cargo insta review` and accept only ordering changes.
+
+- [ ] **Step 4: Run the allocation suite and the determinism guard**
+
+Run: `cargo test -p tt-core --lib allocation`
+Expected: all tests pass, including `many_streams_union_identically_however_the_work_is_scheduled`, `test_total_direct_time_never_exceeds_wall_clock`, and `test_parallel_agent_sessions_sum_delegated_beyond_wall_clock`.
+
+- [ ] **Step 5: Full gates**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass. If insta snapshots changed, `cargo insta review` and confirm every diff is ordering only.
+
+- [ ] **Step 6: Verify numbers and measure CPU utilization**
+
+```bash
+cp ~/.local/share/time-tracker/tt.db /tmp/t4.db
+cargo build --release --bin tt
+TT_DATABASE_PATH=/tmp/t4.db ./target/release/tt report --start 2026-07-20 --end 2026-07-21 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/t4.db ./target/release/tt report --start 2026-07-13 --end 2026-07-20 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/t4.db /usr/bin/time -f 'wall=%es cpu=%P peak_rss=%MKB' ./target/release/tt recompute | tail -3
+```
+
+Expected: same two direct-time figures. `cpu=` now above 100% (it was 99% = one core). Record wall, cpu, and peak_rss.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "perf(allocation): union each stream's intervals in parallel
+
+Streams are independent at union time, so the one genuinely CPU-bound part
+of the pass ran on 1 of 24 cores. rayon was already a dependency and
+already used for ingest parsing. Output is sorted by stream id so results
+do not depend on scheduling; the determinism guard was written first."
+jj new
+```
+
+---
+
+### Task 5: Lock the win in and record it
+
+A performance fix with no guard rots. This task adds a test that fails if allocation ever re-materializes the history, and writes the measured numbers into `AGENTS.md` so the next person does not have to rediscover them.
+
+**Files:**
+- Test: `crates/tt-db/src/lib.rs` (`mod tests`)
+- Modify: `AGENTS.md`
+- Modify: `crates/tt-db/AGENTS.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+
+- [ ] **Step 1: Write a guard that catches re-materialization**
+
+Memory ceilings are not directly assertable in a unit test, so assert the property that actually matters — that allocation over a corpus far larger than any test fixture completes quickly and correctly. A re-introduced `Vec` of every event shows up as a large multiple here. The margin is deliberately generous so this is not a flaky timing test; it exists to catch an order-of-magnitude regression, exactly like `a_chunks_calls_all_run_at_the_same_time` in `classify_auto.rs`.
+
+```rust
+    #[test]
+    fn allocating_a_large_corpus_does_not_scale_with_history_length() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_stream(&make_test_stream("stream-a", "A")).unwrap();
+
+        // 200k focus events across one stream: far more than any fixture, few enough to
+        // stay a unit test.
+        let base = Utc.with_ymd_and_hms(2026, 3, 1, 0, 0, 0).unwrap();
+        let mut batch = Vec::with_capacity(10_000);
+        for index in 0..200_000_i64 {
+            let mut event = make_event(
+                &format!("f{index}"),
+                base + chrono::Duration::seconds(index * 10),
+                EventType::TmuxPaneFocus,
+            );
+            event.stream_id = Some("stream-a".to_string());
+            batch.push(event);
+            if batch.len() == 10_000 {
+                db.insert_events(&batch).unwrap();
+                batch.clear();
+            }
+        }
+        if !batch.is_empty() {
+            db.insert_events(&batch).unwrap();
+        }
+
+        let config = tt_core::AllocationConfig::default();
+        let (first, last) = db.event_time_bounds().unwrap().unwrap();
+        let started = std::time::Instant::now();
+        let result = allocate_for_period(
+            &db,
+            first,
+            last + chrono::Duration::milliseconds(1),
+            None,
+            &config,
+        )
+        .unwrap();
+        let elapsed = started.elapsed();
+
+        // Correct: one stream, and direct time is a union so it cannot exceed the span.
+        assert_eq!(result.stream_times.len(), 1);
+        let span_ms = (last - first).num_milliseconds();
+        assert!(
+            result.stream_times[0].time_direct_ms <= span_ms,
+            "direct {} exceeded span {}",
+            result.stream_times[0].time_direct_ms,
+            span_ms
+        );
+
+        // Fast: streaming this is seconds of work. A re-introduced full materialization
+        // of every event blows past this by an order of magnitude.
+        assert!(
+            elapsed < std::time::Duration::from_secs(60),
+            "allocation took {elapsed:?} for 200k events; something is materializing the history"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it and confirm it passes, and time it**
+
+Run: `cargo test -p tt-db --lib allocating_a_large_corpus_does_not_scale_with_history_length -- --nocapture`
+Expected: PASS. Note the actual elapsed time. If it is anywhere near 60s, the streaming is not working — investigate before continuing rather than raising the bound.
+
+- [ ] **Step 3: Confirm the guard has teeth**
+
+Temporarily revert `allocate_for_period` to the collecting form (`let events = db.get_events_in_range(start, inclusive_end)?;` then `allocate_time(&events, ...)`), run the test, and record what happens — it should be dramatically slower or fail. Then restore the streaming form. Do not commit the reverted state.
+
+Run: `cargo test -p tt-db --lib allocating_a_large_corpus_does_not_scale_with_history_length -- --nocapture`
+Expected (reverted): markedly slower elapsed, or failure. Expected (restored): PASS, fast.
+
+- [ ] **Step 4: Record the measurement in the root `AGENTS.md`**
+
+Add an entry to the **Anti-Patterns** list in `AGENTS.md`, in the voice of the surrounding entries — dated measurements, and the rule stated as a prohibition:
+
+```markdown
+- **Allocation streams the event history and must never materialize it again**: `allocate_time` has always been a single forward walk over timestamp-sorted events with its state in maps, but it took a `&[E]`, and `tt recompute` fed it by loading every row. Measured on the live 2.2 GB corpus (2,738,805 events): **250.48 s wall, 8.9 GB peak RSS, 99% CPU — one of 24 cores** — to produce a per-stream group-by that `sqlite3` answers in **0.73 s and 6.4 MB**. Two full copies were resident, because `recompute::run` loaded the whole history to derive a `MIN`, a `MAX`, and a split-session warning, and then `allocate_for_period` loaded the window again. Both are gone: the bounds and the warning are aggregates (`event_time_bounds`, `sessions_spanning_multiple_streams`), the window streams through `for_each_event_in_range` into `tt_core::allocation::Allocator`, and the missing-start pre-pass is a query (`sessions_with_tool_use_but_no_start`). After: **<RECORD wall/cpu/peak_rss FROM TASK 4 STEP 6>**. `allocating_a_large_corpus_does_not_scale_with_history_length` is the guard, and it was verified to fail against the collecting form. **The slowness had become load-bearing**, which is the part worth remembering: `tt sync` was made 3.6 min → 18.6 s by *deleting* its recompute call, that deletion is now a rule with its own regression test, and `tt streams` labels its totals with their age rather than refreshing them. A 250-second function shaped three other designs before anyone treated it as a defect. Adding a `Vec` of events back into this path re-imposes all of it.
+```
+
+Replace the `<RECORD ...>` marker with the real figures before committing. Also update the existing **`tt sync` must not recompute** entry to note that recomputation is no longer minutes of CPU and gigabytes of RSS — leaving that entry stating the old cost would make two parts of this file disagree. Do **not** delete that rule or re-add `recompute::run` to `sync::run`: the ordering guarantee it protects is separate from its cost, and `tt-cli/tests/sync_no_recompute.rs` guards it.
+
+- [ ] **Step 5: Record the new methods in `crates/tt-db/AGENTS.md`**
+
+Add rows to the **Events** table of the Method Reference:
+
+```markdown
+| `event_time_bounds` | `MIN`/`MAX` of `events.timestamp`, or `None` when empty. What `recompute` used to derive by materializing all 2.7M events |
+| `for_each_event_in_range` | Streaming counterpart of `get_events_in_range`: visits each row in ascending timestamp order without collecting. The allocation pass walks forward only, so it never needed the `Vec` |
+| `sessions_spanning_multiple_streams` | Sessions whose events point at more than one stream, with those streams. A data-integrity report, ordered for stable output |
+| `sessions_with_tool_use_but_no_start` | Sessions with `agent_tool_use` in a window but no `agent_session`/`started` in it — the query form of a pre-pass that used to run over a materialized `Vec` |
+```
+
+And note under the **Allocation entry point** section that `allocate_for_period` now streams into `tt_core::allocation::Allocator` rather than collecting, and that its `end` is still exclusive.
+
+- [ ] **Step 6: Full gates**
+
+Run: `cargo fmt --check && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass.
+
+- [ ] **Step 7: Final end-to-end verification against the live corpus**
+
+```bash
+cp ~/.local/share/time-tracker/tt.db /tmp/final.db
+cargo build --release --bin tt --bin tt-serve
+for range in "2026-07-20 2026-07-21" "2026-07-13 2026-07-20" "2026-06-29 2026-07-06"; do
+  set -- $range
+  TT_DATABASE_PATH=/tmp/final.db ./target/release/tt report --start $1 --end $2 \
+    | grep -E '^(Wall clock|Direct time|Delegated|Leverage):'
+done
+TT_DATABASE_PATH=/tmp/final.db /usr/bin/time -f 'wall=%es cpu=%P peak_rss=%MKB' ./target/release/tt recompute | tail -3
+```
+
+Expected: `Direct time: 16h 23m` for Jul 20 and `74h 20m` for the Jul 13 week. Delegated and Leverage unchanged from a pre-change run of the same command on the same copy — capture both and diff them. Then confirm the daemon still builds and starts, since `tt-serve` links `tt-core`:
+
+```bash
+systemctl --user stop tt-serve.service && sleep 3
+cp target/release/tt-serve ~/.local/bin/tt-serve
+systemctl --user start tt-serve.service && sleep 30
+systemctl --user is-active tt-serve.service
+journalctl --user -u tt-serve.service --since "2 min ago" --no-pager -o cat | grep -ci "ingest failed"
+```
+
+Expected: `active`, and `0` ingest failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+jj describe -m "test(allocation): guard against re-materializing the event history
+
+200k-event corpus through allocate_for_period, asserting correctness and an
+order-of-magnitude time bound. Verified to fail against the collecting
+form. AGENTS.md records the measured before/after and that the old cost had
+become load-bearing: tt sync was sped up by deleting its recompute call
+rather than by fixing recompute."
+jj new
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** The critique was: allocation is single-threaded, materializes everything, and 340× slower than the equivalent database aggregate, and the codebase has been designed around that rather than fixing it. Mapped: redundant full load → Task 1; materialization of the window → Tasks 2 and 3; single-core union → Task 4; regression guard and the load-bearing-slowness note → Task 5. The async-classifier rearchitecture and the read pool are deliberately **not** here — separate subsystems, separate plans, per the skill's scope check.
+
+**Placeholders.** Two intentional `<RECORD ...>` markers in Task 5 Step 4 exist because the numbers do not exist until Task 4 runs; the step says to fill them before committing. Three places instruct the implementer to match existing names they must read (`parse_timestamp`, the interval-union helper near `allocation.rs:727`, the fixture builders in `mod tests`) rather than inventing them — that is deliberate, because guessing a name would be worse than looking, and every one names an exact file and line to look at.
+
+**Type consistency.** `Allocator::{new, push, finish}` is defined in Task 2 and consumed with the same signature in Tasks 3 and 4. `event_time_bounds` returns `Option<(DateTime<Utc>, DateTime<Utc>)>` in Task 1 and is destructured that way in Task 1 Step 9 and Task 5 Step 1. `for_each_event_in_range`'s callback is `FnMut(StoredEvent)` (by value) in Task 3 Step 3 and called as `|event| allocator.push(&event)` in Step 9. `sessions_spanning_multiple_streams` returns `Vec<(String, Vec<String>)>` and is iterated as such.
+
+**Risk flagged for the reviewer.** Task 2 moves roughly 420 lines of the codebase's most correctness-critical function. It is mechanical (`x` → `self.x`) and defended by 55 untouched tests plus a new equivalence test, but it is the task most worth reviewing line by line, and the one where "all tests pass" is least sufficient on its own. The `AllocationConfig`/`period_end` borrow split in `Allocator<'a>` is the likeliest place for a borrow-checker fight that tempts someone into restructuring logic; the instruction is to bind locals instead.

--- a/specs/implementation/2026-08-09-async-classifier-plan.md
+++ b/specs/implementation/2026-08-09-async-classifier-plan.md
@@ -1,0 +1,633 @@
+# Async Classifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the sync/async impedance mismatch in the classifier — an async HTTP stack blocked into a sync trait, then re-parallelized with OS threads — so concurrency is futures rather than thread stacks and the stack stops fighting itself.
+
+**Architecture:** `tt-llm` exposes a **sync** `Classifier` trait. `RigClassifier` satisfies it by owning a `tokio::runtime::Runtime` and calling `block_on` (`crates/tt-llm/src/rig_classifier.rs:243,362`). `tt-cli` then gets concurrency back by spawning OS threads (`classify_auto.rs:514`). Above all of it, `tt-server` is async and calls in through 16 `spawn_blocking` sites. So the call path is: async reqwest → blocked into sync → re-parallelized with threads → invoked from async. This plan makes `Classifier` async, deletes `RigClassifier`'s owned runtime, and replaces `std::thread::scope` with `buffered(CLASSIFY_CONCURRENCY)`. Database writes stay exactly where they are: serial, on the one connection the `Resolver` holds.
+
+**Tech Stack:** Rust (edition 2021), `async-trait` (**new dependency — the trait is used as `&dyn Classifier`, and native `async fn` in traits is not dyn-compatible**), `tokio` 1 (already a workspace dependency, `features = ["full"]`), `futures-util` 0.3 (already a workspace dependency), rig-core.
+
+## What this does NOT buy, stated up front
+
+**This plan does not make classification faster today, and anyone executing it expecting a speedup will be disappointed.** Measured 2026-08-09 on the live daemon: at `CLASSIFY_CONCURRENCY = 8` the drain was **7.1 real sessions/min with 0 rate-limit (429) and 0 overloaded (529) responses**; at 16 it was **8.0/min with 2 429s and 6 529s**. The provider is the constraint above 8, not the concurrency mechanism. Eight OS threads parked on network I/O cost microseconds of scheduling against 15–90 second calls.
+
+What it buys is: one runtime instead of two, no thread stack per in-flight call, concurrency that is cheap to raise **if provider limits ever move**, and a `tt-llm` whose shape matches the I/O it actually does. Those are real, and they are architectural rather than metric. **Acceptance is parity, not improvement** — see Task 5.
+
+## Global Constraints
+
+- **No behavior change.** `tt report` for `2026-07-20` prints `Direct time: 16h 23m`; `2026-07-13..2026-07-20` prints `74h 20m`. Before and after, on a copy of the live database.
+- **Database writes stay serial on one connection.** `Resolver::stream_named` is a non-transactional find-and-insert; two concurrent copies re-create the duplicate-stream failure that cost 55 renames, 5 merges and 9 dissolves to undo. Today the compiler enforces this because `tt_db::Database` is `Send` but not `Sync` and cannot cross into a `thread::scope` closure. **When the closure becomes a future, that protection weakens: a non-`Send` value can still live across an `.await` in a single-threaded context, and `buffered` does not move the resolver.** The plan keeps writes outside the concurrent section entirely (Task 3) — never move a `Database` into a future.
+- **Order of applied verdicts must stay deterministic** (the chunk's own order). `futures_util::stream::buffered` preserves input order; `buffer_unordered` does **not**. Use `buffered`.
+- Every existing guard is untouched: junk rules, `is_misnamed_stream`, `stream_exists` validation, subagent inheritance, proposal duplicate-guards, `CLASSIFIER_GENERATION` gating, the retry/timeout/deadline bounds in `transport.rs`.
+- `MAX_MODEL_TURNS`, `MAX_FETCH_CALLS`, `REQUEST_TIMEOUT`, `MAX_CLASSIFICATION_MS`, `MAX_PARSE_ATTEMPTS`, `MAX_TRANSPORT_RETRIES` keep their exact values and meanings.
+- `unsafe_code` denied. Zero clippy warnings (CI is `-D warnings`). `cargo fmt` clean (`max_width = 100`).
+- Errors: `thiserror` (`LlmError`) in `tt-llm`, `anyhow` in `tt-cli`/`tt-server`.
+- **jj, not git.** `jj describe -m "..."` then `jj new`. Never `git`. Never backticks or `$(...)` inside a double-quoted `-m` message — use `jj describe --stdin < file` for those.
+
+## File Structure
+
+| File | Responsibility after this plan |
+|---|---|
+| `Cargo.toml` (modify) | Adds `async-trait` to `[workspace.dependencies]`. |
+| `crates/tt-llm/Cargo.toml` (modify) | Depends on `async-trait`. |
+| `crates/tt-llm/src/types.rs` (modify, ~`Classifier` at 193, `MockClassifier` at 252) | `Classifier` becomes an async trait. `MockClassifier` implements it. |
+| `crates/tt-llm/src/rig_classifier.rs` (modify, 243/275/324/356/394) | Loses its owned `Runtime`; `classify`, `describe_stream`, `classify_with_tools`, `extract`, `within` become async. |
+| `crates/tt-llm/src/transport.rs` (modify) | `retrying` becomes async so it can `tokio::time::sleep` instead of blocking a thread. |
+| `crates/tt-cli/src/commands/classify_auto.rs` (modify, `classify_concurrently` ~505) | Concurrency via `buffered(CLASSIFY_CONCURRENCY)` on a runtime handle instead of `std::thread::scope`. |
+| `crates/tt-cli/src/commands/classify_auto/resolver.rs` (modify, `classify` at 75) | Awaits the classifier through the caller's runtime; health recording unchanged. |
+| `crates/tt-cli/src/commands/streams/describe.rs` (modify, ~41) | Drives `describe_stream` on a runtime. |
+| `crates/tt-cli/src/main.rs` (modify, `fn main` at 39) | Owns one runtime for the commands that call a model. |
+| `crates/tt-server/src/loops/operations.rs` (modify, ~86) | Classification stops going through `spawn_blocking` for the model calls. |
+
+---
+
+### Task 1: Make `Classifier` an async trait, with `RigClassifier` temporarily bridged
+
+Change the trait and `MockClassifier` first, keeping `RigClassifier` compiling via its existing runtime. This isolates the trait change from the rig rewrite so a reviewer can reject one without the other.
+
+**Files:**
+- Modify: `Cargo.toml`, `crates/tt-llm/Cargo.toml`, `crates/tt-llm/src/types.rs`
+- Modify: `crates/tt-llm/src/rig_classifier.rs` (bridge only)
+- Test: `crates/tt-llm/src/types.rs` (`mod tests`)
+
+**Interfaces:**
+- Produces:
+  - `#[async_trait::async_trait] pub trait Classifier: Send + Sync { async fn classify(&self, input: &ClassificationInput, roster: &[StreamSummary]) -> Result<ClassificationOutput, LlmError>; async fn describe_stream(&self, evidence: &str) -> Result<String, LlmError>; }`
+
+- [ ] **Step 1: Add the dependency**
+
+In the root `Cargo.toml`, under `[workspace.dependencies]`, alongside the existing `tokio` (line 52) and `futures-util` (line 54):
+
+```toml
+async-trait = "0.1"
+```
+
+In `crates/tt-llm/Cargo.toml`, under `[dependencies]`:
+
+```toml
+async-trait.workspace = true
+```
+
+- [ ] **Step 2: Run `cargo deny` before relying on the dependency**
+
+Run: `cargo deny check`
+Expected: no new advisories or license failures. CI runs this in the Lint job; a dependency that fails it must not be added.
+
+- [ ] **Step 3: Write the failing test**
+
+Add to `mod tests` in `crates/tt-llm/src/types.rs`:
+
+```rust
+    #[tokio::test]
+    async fn a_mock_classifier_answers_through_the_async_trait() {
+        let classifier = MockClassifier::new(vec![Ok(ClassificationOutput {
+            choice: StreamChoice::Existing {
+                stream_id: "stream-a".to_string(),
+            },
+            confidence: 0.9,
+            reasoning: "clear".to_string(),
+        })]);
+
+        let input = ClassificationInput {
+            session_id: "session-1".to_string(),
+            machine: None,
+            cwd: None,
+            starting_prompt: None,
+            user_prompts: Vec::new(),
+            window_titles: Vec::new(),
+            started_at: None,
+        };
+
+        let output = classifier.classify(&input, &[]).await.unwrap();
+        assert_eq!(output.confidence, 0.9);
+    }
+```
+
+Match the real constructor and field names of `MockClassifier`, `ClassificationOutput`, `StreamChoice`, and `ClassificationInput` by reading `crates/tt-llm/src/types.rs` — the shapes above follow the existing tests in that file, but use the actual names.
+
+`tokio` must be available as a dev-dependency of `tt-llm` for `#[tokio::test]`; it is already a normal dependency, which is sufficient.
+
+- [ ] **Step 4: Run it and confirm it fails**
+
+Run: `cargo test -p tt-llm --lib a_mock_classifier_answers_through_the_async_trait`
+Expected: compile error — `.await` on a non-future, or `classify` is not async.
+
+- [ ] **Step 5: Make the trait async**
+
+In `crates/tt-llm/src/types.rs`, replace the trait at line 193:
+
+```rust
+/// A model that can place work on a stream.
+///
+/// Async because every implementation of it does network I/O. It was sync, and
+/// `RigClassifier` paid for that by owning a `tokio::runtime::Runtime` and calling
+/// `block_on` — so an async HTTP stack was blocked into a sync call, which callers then
+/// re-parallelized with OS threads, from inside an async daemon. One runtime, one shape.
+///
+/// `async_trait` rather than a native `async fn` in trait: this is used as
+/// `&dyn Classifier` throughout (`Resolver` holds one, `run_auto` takes one), and native
+/// `async fn` in traits is not dyn-compatible.
+#[async_trait::async_trait]
+pub trait Classifier: Send + Sync {
+    /// Places one unit of work, choosing from `roster` or proposing something new.
+    ///
+    /// # Errors
+    /// [`LlmError`] when the provider refuses, the output cannot be parsed, or the
+    /// classification exceeds its deadline.
+    async fn classify(
+        &self,
+        input: &ClassificationInput,
+        roster: &[StreamSummary],
+    ) -> Result<ClassificationOutput, LlmError>;
+
+    /// Writes a one-line description of a stream from evidence drawn from its work.
+    ///
+    /// # Errors
+    /// [`LlmError`] when the provider refuses or the output cannot be parsed.
+    async fn describe_stream(&self, evidence: &str) -> Result<String, LlmError>;
+}
+```
+
+Then annotate `impl Classifier for MockClassifier` (line 252) with `#[async_trait::async_trait]` and make both its methods `async fn`. Its bodies are synchronous and stay exactly as they are — an `async fn` with no `.await` is a ready future, which is correct for a scripted mock.
+
+- [ ] **Step 6: Bridge `RigClassifier` so the crate still compiles**
+
+Annotate `impl Classifier for RigClassifier` (`crates/tt-llm/src/rig_classifier.rs:394`) with `#[async_trait::async_trait]`, make both methods `async fn`, and leave their bodies calling the existing sync internals — which still use `self.runtime.block_on`. Add a comment marking it temporary:
+
+```rust
+// TEMPORARY BRIDGE (removed in Task 2): the body below still drives the owned runtime
+// with `block_on`. Calling `block_on` from inside an async context panics, so nothing may
+// await this impl on a runtime thread until Task 2 lands. The only caller today is
+// `tt-cli`, which is still fully synchronous at this point in the plan.
+```
+
+This is the one step of this plan that leaves the tree in a knowingly half-migrated state. Task 2 immediately follows and removes it; do not ship Task 1 on its own to a running daemon.
+
+- [ ] **Step 7: Run it and confirm the trait test passes**
+
+Run: `cargo test -p tt-llm --lib a_mock_classifier_answers_through_the_async_trait`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 8: Make the rest of the workspace compile**
+
+`cargo check --all-targets` will now fail at every call site. Fix each **minimally**, by wrapping in the caller's existing sync context with a local runtime, so this task changes only the trait:
+
+- `crates/tt-cli/src/commands/classify_auto/resolver.rs:76`
+- `crates/tt-cli/src/commands/classify_auto.rs:514`
+- `crates/tt-cli/src/commands/streams/describe.rs:41`
+- `crates/tt-llm/src/rig_classifier.rs` tests at 963 and 1032 (make them `#[tokio::test] async fn` and `.await`)
+
+For the `tt-cli` sites, the minimal bridge is a single module-level runtime created once:
+
+```rust
+/// Drives one async classifier call from synchronous code.
+///
+/// Scaffolding for the async migration: removed in Task 4, when `tt-cli` owns one runtime
+/// at `main` instead of creating them at call sites.
+fn block_on_classifier<T>(future: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("a current-thread runtime is buildable")
+        .block_on(future)
+}
+```
+
+- [ ] **Step 9: Full gates**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass (baseline 1,154 plus the new one).
+
+- [ ] **Step 10: Commit**
+
+```bash
+jj describe -m "refactor(tt-llm): make Classifier an async trait
+
+Every implementation does network I/O, and the sync signature forced
+RigClassifier to own a runtime and block_on inside it. async-trait rather
+than a native async fn in trait, because this is used as &dyn Classifier.
+RigClassifier is bridged here and rewritten next."
+jj new
+```
+
+---
+
+### Task 2: Delete `RigClassifier`'s owned runtime
+
+**Files:**
+- Modify: `crates/tt-llm/src/rig_classifier.rs` (243, 252-258, 275, 324, 356-362, 394-410, 943)
+- Modify: `crates/tt-llm/src/transport.rs` (`retrying`)
+- Test: `crates/tt-llm/src/transport/tests.rs`, `crates/tt-llm/src/rig_classifier.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: the async `Classifier` trait from Task 1.
+- Produces:
+  - `RigClassifier` with **no** `runtime` field.
+  - `async fn RigClassifier::within<T>(&self, deadline: &Deadline, future: impl Future<Output = T> + Send) -> Result<T, LlmError>`
+  - `async fn transport::retrying<T, F, Fut>(deadline: &Deadline, attempt: F) -> Result<T, LlmError> where F: FnMut() -> Fut, Fut: Future<Output = Result<T, AttemptFailure>>`
+
+- [ ] **Step 1: Write the failing test — no runtime field, and it works on the caller's runtime**
+
+```rust
+    #[tokio::test]
+    async fn a_classification_runs_on_the_callers_runtime() {
+        // Given: a classifier pointed at a local socket that never answers, so the call
+        // resolves through the timeout path rather than the network.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let classifier = RigClassifier::for_test_against(&format!("http://{addr}"));
+
+        // When: awaited directly on this test's runtime — no block_on anywhere.
+        let input = test_input();
+        let result = classifier.classify(&input, &[]).await;
+
+        // Then: it returns an error rather than panicking with "cannot block_on from
+        // within a runtime", which is what an owned runtime would do here.
+        assert!(result.is_err(), "expected a transport failure, got {result:?}");
+    }
+```
+
+Use the real constructor the existing tests at `rig_classifier.rs:943` and `:1032` use for a test classifier — that line currently builds one with `runtime: tokio::runtime::Runtime::new()`, so it will need updating in Step 3 anyway. Name the helper `for_test_against` only if no equivalent exists; otherwise use the existing one.
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cargo test -p tt-llm --lib a_classification_runs_on_the_callers_runtime`
+Expected: panic `Cannot start a runtime from within a runtime`, or a compile error on the test constructor.
+
+- [ ] **Step 3: Remove the runtime and make the internals async**
+
+In `crates/tt-llm/src/rig_classifier.rs`:
+
+1. Delete the `runtime: tokio::runtime::Runtime` field (line 243) and its construction (lines 252–258) and the test construction at 943.
+2. `within` (line 356) becomes async and awaits the timeout directly instead of `block_on`ing it:
+
+```rust
+    /// Bounds one attempt by what is left of the whole classification's allowance.
+    ///
+    /// The timeout is constructed *inside* the async block rather than around a
+    /// `block_on`, so the clock starts when the future is polled.
+    async fn within<T>(
+        &self,
+        deadline: &Deadline,
+        future: impl std::future::Future<Output = T> + Send,
+    ) -> Result<T, LlmError> {
+        let Some(remaining) = deadline.remaining() else {
+            return Err(LlmError::Timeout);
+        };
+        tokio::time::timeout(remaining, future)
+            .await
+            .map_err(|_| LlmError::Timeout)
+    }
+```
+
+Match the existing error variant and `Deadline` API exactly — read lines 351–370 and `crates/tt-llm/src/transport.rs` before writing this; the shape above must not invent a `LlmError::Timeout` if the real variant is named differently.
+
+3. `classify_with_tools` (275), `extract` (324), `classify` (395) and `describe_stream` (403) become `async fn` and `.await` the rig calls they currently drive through `block_on`.
+4. The custom HTTP send at lines 513–519 builds its own current-thread runtime to call `HttpClientExt::send`. Make that function async and `.await` the send; delete the runtime.
+
+- [ ] **Step 4: Make `transport::retrying` async**
+
+The retry ladder currently sleeps by blocking. Convert it so it awaits:
+
+```rust
+/// Runs `attempt` until it succeeds, is refused, or spends one of the three bounds.
+///
+/// Async so a waiting retry parks a task instead of a thread. The three bounds are
+/// unchanged: at most `MAX_TRANSPORT_RETRIES` retries, at most 20s of cumulative wait,
+/// and the classification-wide `Deadline`.
+pub(crate) async fn retrying<T, F, Fut>(
+    deadline: &Deadline,
+    mut attempt: F,
+) -> Result<T, LlmError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, AttemptFailure>>,
+{
+    // ... same control flow as today, with `std::thread::sleep(wait)` replaced by
+    // `tokio::time::sleep(wait).await`
+}
+```
+
+**Change no bound, no jitter, no `Retry-After` handling, and no `is_transient` decision** — only how the wait is performed. `HttpFailure::is_transient` is the single place the status line is drawn and must not move.
+
+- [ ] **Step 5: Run the transport and classifier suites**
+
+Run: `cargo test -p tt-llm`
+Expected: all tests pass. The timeout tests in `transport/tests.rs` build their error through rig's real transport against a local never-answering socket; they must still pass, and they are what catch a split `reqwest` in the dependency graph.
+
+- [ ] **Step 6: Run it and confirm the Step 1 test passes**
+
+Run: `cargo test -p tt-llm --lib a_classification_runs_on_the_callers_runtime`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 7: Confirm the runtime is actually gone**
+
+Run: `grep -n "block_on\|tokio::runtime::Runtime" crates/tt-llm/src/`
+Expected: **no matches** in non-test code. Any remaining match is an unmigrated path.
+
+- [ ] **Step 8: Full gates**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+jj describe -m "refactor(tt-llm): drop RigClassifier's owned runtime
+
+It built a tokio Runtime per classifier and block_on'd every model call
+inside it, so an async HTTP stack was driven synchronously and then
+re-parallelized by callers with OS threads. Calls now run on the caller's
+runtime and retry waits park a task instead of a thread. Bounds, jitter,
+Retry-After handling and is_transient are untouched."
+jj new
+```
+
+---
+
+### Task 3: Replace `std::thread::scope` with `buffered`
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/classify_auto.rs` (`classify_concurrently` ~505, `classify_sessions`)
+- Modify: `crates/tt-cli/src/commands/classify_auto/resolver.rs` (`classify` at 75, `record_call`)
+- Modify: `crates/tt-cli/Cargo.toml` (add `futures-util.workspace = true`)
+- Test: `crates/tt-cli/src/commands/classify_auto.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: async `Classifier` (Task 1), runtime-free `RigClassifier` (Task 2).
+- Produces: `Resolver::classify_concurrently` returning `Vec<Result<ClassificationOutput, LlmError>>` in the chunk's input order, as today.
+
+- [ ] **Step 1: Keep the existing concurrency guard, and confirm it still guards**
+
+`a_chunks_calls_all_run_at_the_same_time` in `classify_auto.rs` is the only test that fails if the calls go serial — verified at 35.01s serial versus 0.01s concurrent. **It must survive this task unmodified except for whatever the async signature forces.** Read it before changing anything, and keep its condvar barrier: a barrier that all N calls must reach proves genuine concurrency, and it works identically for futures on a multi-threaded runtime.
+
+- [ ] **Step 2: Run it and record the current pass time**
+
+Run: `cargo test -p tt-cli --lib a_chunks_calls_all_run_at_the_same_time -- --nocapture`
+Expected: PASS, fast (about 0.01s).
+
+- [ ] **Step 3: Add `futures-util` to `tt-cli`**
+
+In `crates/tt-cli/Cargo.toml` under `[dependencies]`:
+
+```toml
+futures-util.workspace = true
+```
+
+- [ ] **Step 4: Rewrite `classify_concurrently`**
+
+Replace the `std::thread::scope` body with a buffered stream, driven on a runtime handle:
+
+```rust
+    /// Runs one chunk's model calls at the same time, answering in the chunk's order.
+    ///
+    /// `buffered` rather than `buffer_unordered`: verdicts are applied in the chunk's own
+    /// order so a pass is reproducible, and unordered completion would make the applied
+    /// order depend on which call finished first.
+    ///
+    /// `&self` rather than `&mut self` is still load-bearing. Only the classifier and a
+    /// shared roster slice cross into the futures. **The database must never cross**: it
+    /// is `Send` but not `Sync`, and where `thread::scope` had the compiler refuse it
+    /// outright, a future can hold a non-`Send` value across an `.await`. Writes stay
+    /// outside this function entirely, applied serially by the caller.
+    fn classify_concurrently(
+        &self,
+        chunk: &[(ClassificationInput, u32)],
+    ) -> Vec<Result<ClassificationOutput, LlmError>> {
+        use futures_util::stream::{self, StreamExt};
+
+        let classifier = self.classifier;
+        let roster = self.roster.as_slice();
+        self.runtime.block_on(async move {
+            stream::iter(chunk.iter().map(|(input, _)| input))
+                .map(|input| classifier.classify(input, roster))
+                .buffered(CLASSIFY_CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await
+        })
+    }
+```
+
+`self.runtime` is a `tokio::runtime::Handle` added to `Resolver` in Task 4. Until then, use the `block_on_classifier` helper from Task 1 Step 8 so this task compiles on its own.
+
+Delete the `panicked(&*payload)` helper and the `JoinHandle::join` error handling: a future that panics propagates through `buffered` differently, and `Task 3 Step 6` covers it. **Do not delete the panic *test*** — rewrite it (Step 6).
+
+- [ ] **Step 5: Run the concurrency guard again**
+
+Run: `cargo test -p tt-cli --lib a_chunks_calls_all_run_at_the_same_time -- --nocapture`
+Expected: PASS, still fast. If it now hangs, the runtime is single-threaded — `buffered` on a current-thread runtime still interleaves at `.await` points, but the test's condvar **blocks** the thread rather than awaiting, so a current-thread runtime deadlocks. Use a multi-threaded runtime (Task 4 makes this the real configuration) or convert the barrier to `tokio::sync::Barrier` and the mock to an async sleep.
+
+- [ ] **Step 6: Restore the panic guarantee as a test**
+
+`a_panicking_worker_costs_its_own_session_and_no_other` must keep its meaning: one failing call costs its own session and nothing else. With futures, a panic inside `buffered` unwinds the whole `block_on`. Restore the guarantee by catching per call:
+
+```rust
+                .map(|input| async move {
+                    // A panicking call costs its own session, exactly as a panicking
+                    // worker thread did: it becomes a failed classification, counted and
+                    // recorded, with the session left unassigned.
+                    match futures_util::FutureExt::catch_unwind(
+                        std::panic::AssertUnwindSafe(classifier.classify(input, roster)),
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(payload) => Err(panicked(&*payload)),
+                    }
+                })
+```
+
+Keep the existing `panicked(&(dyn Any + Send)) -> LlmError` helper for this; it is still the right conversion. Run the existing panic test and confirm it still asserts 2 assigned, 1 error, `api: 1`, and a `last_error` containing `panicked`.
+
+- [ ] **Step 7: Full gates**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass — including `one_chunk_naming_one_new_stream_many_times_creates_it_once`, which proves concurrent verdicts still collapse onto one stream row.
+
+- [ ] **Step 8: Commit**
+
+```bash
+jj describe -m "refactor(classify): run a chunk's calls as futures, not threads
+
+std::thread::scope parked an OS thread per in-flight model call. buffered
+keeps the chunk's input order, so applied verdicts stay deterministic;
+buffer_unordered would not. Writes are still outside the concurrent
+section and still serial on the resolver's one connection."
+jj new
+```
+
+---
+
+### Task 4: One runtime, owned at the top
+
+**Files:**
+- Modify: `crates/tt-cli/src/main.rs` (`fn main` at 39)
+- Modify: `crates/tt-cli/src/commands/classify_auto.rs` (`run_auto` at 649), `classify_auto/resolver.rs` (`Resolver::new`)
+- Modify: `crates/tt-cli/src/commands/streams/describe.rs` (~41)
+- Modify: `crates/tt-server/src/loops/operations.rs` (~86)
+
+**Interfaces:**
+- Produces:
+  - `run_auto(db: &tt_db::Database, config: &Config, classifier: &dyn Classifier, runtime: tokio::runtime::Handle) -> Result<AutoClassifyOutcome>`
+  - `Resolver` gains `runtime: tokio::runtime::Handle`.
+
+- [ ] **Step 1: Give `tt-cli` a runtime at `main`**
+
+`crates/tt-cli/src/main.rs:39` is `fn main() -> Result<()>`. Keep it synchronous — `tt` is a CLI and most subcommands touch no network — and build one multi-threaded runtime, passing its `Handle` only to the commands that call a model:
+
+```rust
+fn main() -> Result<()> {
+    // One runtime for the whole process. Only the model-calling commands use it, but a
+    // single owner beats a runtime built per call site, which is what the migration
+    // scaffolding did.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("build the async runtime")?;
+    // ... existing arg parsing and dispatch, passing runtime.handle().clone() to the
+    // classify and describe commands
+}
+```
+
+**Multi-threaded, not current-thread**: `buffered` on a current-thread runtime still interleaves at await points, but any blocking call inside a future (the mock's condvar in tests, or a stray synchronous DB read) stalls every other in-flight call.
+
+- [ ] **Step 2: Thread the handle through**
+
+Add `runtime: tokio::runtime::Handle` to `Resolver` and to `run_auto`'s signature. Replace every use of the temporary `block_on_classifier` helper with `self.runtime.block_on(...)`, then **delete that helper**. Update `crates/tt-cli/src/commands/streams/describe.rs:41` to drive `describe_stream` on the same handle.
+
+- [ ] **Step 3: Stop the daemon double-wrapping**
+
+`crates/tt-server/src/loops/operations.rs:86` runs `run_auto` inside `tokio::task::spawn_blocking`. That is still correct — `run_auto` performs blocking SQLite work between chunks and must not run on an async worker — but it must now be handed the runtime handle:
+
+```rust
+    let handle = tokio::runtime::Handle::current();
+    tokio::task::spawn_blocking(move || -> Result<ClassifyAttempt> {
+        // ...
+        match tt_cli::commands::classify_auto::run_auto(&db, &config, &*classifier, handle) {
+```
+
+**`Handle::block_on` from inside `spawn_blocking` is allowed** — `spawn_blocking` runs on a dedicated blocking thread, not an async worker. Calling it from an async worker would panic. Confirm at runtime in Step 5, not by reasoning alone.
+
+- [ ] **Step 4: Full gates**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass.
+
+Then confirm nothing builds a runtime outside `main` and the daemon:
+
+Run: `grep -rn "Runtime::new\|new_current_thread\|new_multi_thread" crates/ --include=*.rs | grep -v test`
+Expected: exactly one match, in `crates/tt-cli/src/main.rs`.
+
+- [ ] **Step 5: Prove it on the live daemon before trusting it**
+
+```bash
+cd /home/sami/Code/time-tracker/default
+cargo build --release --bin tt --bin tt-serve
+systemctl --user stop tt-serve.service && sleep 3
+cp target/release/tt-serve ~/.local/bin/tt-serve
+cp target/release/tt ~/.local/bin/tt
+systemctl --user start tt-serve.service && sleep 120
+systemctl --user is-active tt-serve.service
+systemctl --user show tt-serve.service -p NRestarts --value
+journalctl --user -u tt-serve.service --since "3 min ago" --no-pager -o cat \
+  | sed 's/\x1b\[[0-9;]*m//g' | grep -icE "cannot start a runtime|cannot block_on|panic"
+```
+
+Expected: `active`, `0` restarts, and **`0`** runtime/panic messages. A `Cannot start a runtime from within a runtime` panic here means `block_on` reached an async worker thread; that is the one failure mode this task can introduce, and it will not show up in unit tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "refactor(cli): own one runtime at main and thread its handle
+
+Migration scaffolding built a current-thread runtime per call site. tt now
+builds one multi-threaded runtime and hands its Handle to the commands that
+call a model. The daemon keeps spawn_blocking around run_auto, which is
+where block_on is legal, and passes the ambient handle in."
+jj new
+```
+
+---
+
+### Task 5: Verify parity and record what this did and did not buy
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `crates/tt-llm/src/lib.rs` (module docs) or `crates/tt-llm/AGENTS.md` if one exists
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4 — the async `Classifier` trait, the runtime-free `RigClassifier`, `classify_concurrently`'s `buffered` stream, and `run_auto`'s `runtime: tokio::runtime::Handle` parameter.
+- Produces: no code interface. Produces the measured parity figures that the `AGENTS.md` entry cites, and which any future change to `CLASSIFY_CONCURRENCY` or the concurrency mechanism must be compared against.
+
+- [ ] **Step 1: Measure the drain, the same way it was measured before**
+
+```bash
+cd /home/sami/Code/time-tracker/default
+DB=~/.local/share/time-tracker/tt.db
+real(){ sqlite3 -noheader "$DB" "SELECT count(*) FROM agent_sessions s WHERE s.session_type='user' AND s.session_id NOT IN(SELECT session_id FROM classified_sessions) AND NOT(s.tool_call_count=0 AND s.message_count<=2);"; }
+a=$(real); sleep 900; b=$(real)
+echo "real/min: $(echo "scale=1;($a-$b)*60/900"|bc)"
+journalctl --user -u tt-serve.service --since "16 min ago" --no-pager -o cat \
+  | sed 's/\x1b\[[0-9;]*m//g' \
+  | { j=$(cat); printf "429=%s 529=%s errors=%s ingest-failures=%s\n" \
+      "$(echo "$j"|grep -ciE '429|rate.?limit')" "$(echo "$j"|grep -c 529)" \
+      "$(echo "$j"|grep -c 'resolver: automatic classification failed')" \
+      "$(echo "$j"|grep -c 'session ingest failed')"; }
+```
+
+Expected: **~7 real/min, 0 429, 0 529, 0 ingest failures** — parity with the thread-based implementation measured 2026-08-09. **Parity is success.** A large improvement would be surprising and worth investigating rather than celebrating, since the provider is the constraint; a regression means a future is being awaited serially somewhere.
+
+- [ ] **Step 2: Verify the numbers**
+
+```bash
+cp ~/.local/share/time-tracker/tt.db /tmp/async.db
+TT_DATABASE_PATH=/tmp/async.db ./target/release/tt report --start 2026-07-20 --end 2026-07-21 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/async.db ./target/release/tt report --start 2026-07-13 --end 2026-07-20 | grep '^Direct time:'
+sqlite3 -noheader "$DB" "SELECT count(*) FROM(SELECT trim(name) FROM streams WHERE name IS NOT NULL GROUP BY trim(name) HAVING count(*)>1);"
+```
+
+Expected: `16h 23m`, `74h 20m`, and **0** duplicate stream names — the last is the guard that concurrent verdicts still collapse onto one row.
+
+- [ ] **Step 3: Record it in `AGENTS.md`**
+
+Add to the Anti-Patterns list, in the voice of its neighbours:
+
+```markdown
+- **The classifier is async because its work is I/O, and it must not acquire a second runtime**: `Classifier` was a sync trait, so `RigClassifier` owned a `tokio::runtime::Runtime` and `block_on`'d every model call inside it, `tt-cli` re-parallelized those blocking calls with `std::thread::scope`, and `tt-server` invoked the result from an async daemon through `spawn_blocking`. Async HTTP, blocked, re-threaded, called from async. The trait is now async (`async_trait`, because it is used as `&dyn Classifier` and native `async fn` in traits is not dyn-compatible), `tt` owns exactly one multi-threaded runtime at `main`, and a chunk's calls run through `buffered(CLASSIFY_CONCURRENCY)` — **`buffered`, never `buffer_unordered`**, because verdicts are applied in the chunk's own order so a pass is reproducible. **This bought no throughput and was not expected to**: measured before and after at ~7 real sessions/min, because the provider rate-limits above `CLASSIFY_CONCURRENCY = 8` (16 produced 2 429s and 6 529s for +18%). What it removed is the second runtime and a thread stack per in-flight call. The daemon still wraps `run_auto` in `spawn_blocking`, and must: `Handle::block_on` is legal on a blocking thread and panics on an async worker. **Database writes stay outside the concurrent section and stay serial** — `thread::scope` used to make that a compile error, since `Database` is `Send` but not `Sync`; a future can hold a non-`Send` value across an `.await`, so the guarantee is now structural (the resolver applies verdicts after the stream completes) rather than compiler-enforced. Moving a `Database` into one of these futures re-creates the duplicate-stream failure that cost 55 renames, 5 merges and 9 dissolves.
+```
+
+Also update the **Async** subsection of `AGENTS.md`'s Code Conventions, which currently states that `tt-llm` exposes a sync `Classifier` and drives rig on an internal runtime. Leaving it would make two parts of the file disagree.
+
+- [ ] **Step 4: Full gates and commit**
+
+Run: `cargo fmt --check && cargo clippy --all-targets && cargo test && cargo deny check`
+Expected: all clean.
+
+```bash
+jj describe --stdin <<'MSG'
+docs(agents): record the async classifier migration and its null result
+
+Parity, not improvement: ~7 real sessions/min before and after, because the
+provider rate-limits above CLASSIFY_CONCURRENCY=8. What went away is the
+second tokio runtime and a thread stack per in-flight call. Notes that the
+serial-write guarantee is now structural rather than compiler-enforced.
+MSG
+jj new
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** The critique was that the stack blocks an async HTTP client into a sync trait and then re-parallelizes with OS threads, from inside an async daemon. Task 1 makes the trait async, Task 2 deletes the owned runtime and un-blocks the retry ladder, Task 3 replaces threads with futures, Task 4 consolidates on one runtime, Task 5 verifies parity and records it.
+
+**Placeholders.** None. Three steps instruct matching real names in files they name with line numbers (`MockClassifier`'s constructor, `Deadline`'s API and the timeout error variant, the test classifier constructor at `rig_classifier.rs:943`) — deliberate, because guessing a name is worse than reading one.
+
+**Type consistency.** `Classifier::{classify, describe_stream}` are async from Task 1 and awaited in Tasks 2–4. `within` and `retrying` gain `async` in Task 2 and are used that way inside `RigClassifier`. `run_auto` gains `runtime: tokio::runtime::Handle` in Task 4 and is called with it from `operations.rs`. `classify_concurrently` keeps returning `Vec<Result<ClassificationOutput, LlmError>>` in input order throughout.
+
+**Risks flagged for the reviewer.**
+1. **Task 1 leaves the tree knowingly half-migrated** (async trait, `RigClassifier` still blocking internally). It is the one point in this plan where the tree must not be deployed. Task 2 immediately follows.
+2. **The serial-write guarantee changes character.** Today `thread::scope` plus `Database: !Sync` makes a stray database access inside the concurrent section a compile error. With futures that protection is weaker. This is the single most important thing for a reviewer to check by hand, and it is why Task 3's doc comment says so in the code rather than only here.
+3. **`buffered` versus `buffer_unordered`** is a one-word difference that silently makes verdict application order depend on completion order. Named in the constraints, in Task 3's code comment, and in the `AGENTS.md` entry.
+4. **`Handle::block_on` panics on an async worker thread** and no unit test will catch it; Task 4 Step 5 checks the live daemon's journal for exactly that panic.

--- a/specs/implementation/2026-08-09-read-pool-plan.md
+++ b/specs/implementation/2026-08-09-read-pool-plan.md
@@ -1,0 +1,323 @@
+# Classifier Read Pool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop every concurrent classification worker serializing its session fetches on a single `Mutex<Database>`, by giving the classifier a small pool of read connections — **but only if measurement shows the contention is real.**
+
+**Architecture:** `DbSessionDetail` (`crates/tt-cli/src/commands/classify_auto/session_detail.rs:45`) holds `db: Mutex<Database>`. Every worker in a `CLASSIFY_CONCURRENCY`-wide chunk that fetches session detail mid-classification takes that one lock, so fetches are serial across the whole chunk. SQLite in WAL mode supports unlimited concurrent readers; we are not using that. This plan replaces the single mutex with a fixed-size pool of read-only connections handed out and returned through a channel.
+
+**Tech Stack:** Rust (edition 2021), rusqlite 0.34, `std::sync::mpsc` (no new dependencies).
+
+## Task 0 is a kill switch
+
+**This plan begins by measuring, and is designed to be abandoned at Task 1 Step 4 if the number is small.** The model call is 15–90 seconds; a session fetch is a handful of indexed SQLite reads. If lock wait is a rounding error against that, building a pool is complexity for nothing, and this repo has a standing habit of reverting changes that measure badly (see `CLASSIFY_CONCURRENCY` in `crates/tt-cli/src/commands/classify_auto.rs`, where 16 was tried and reverted for +18% at the cost of rate limiting). Do not treat reaching Task 2 as the success condition.
+
+## Global Constraints
+
+- **No behavior change whatsoever.** This is purely how reads are served. `tt report` for `2026-07-20` must print `Direct time: 16h 23m` and `2026-07-13..2026-07-20` must print `Direct time: 74h 20m` before and after.
+- **Reads only.** The classifier's *writes* stay exactly where they are: on the one `Database` the `Resolver` holds, applied serially. That serialization is a correctness guarantee — `stream_named` is a non-transactional find-and-insert, and two concurrent copies re-create the duplicate-stream failure that cost 55 renames, 5 merges and 9 dissolves. **Nothing in this plan may hand a write path more than one connection.**
+- Every pooled connection is opened with `Database::open`, which applies `busy_timeout(30s)`, `synchronous = NORMAL`, and the schema check. Do not open raw `rusqlite::Connection`s.
+- Pool size is bounded and never grows on demand: an unbounded pool is a file-descriptor leak with extra steps.
+- `unsafe_code` denied. Zero clippy warnings (`-D warnings` in CI). `cargo fmt` clean.
+- No new dependencies.
+- **jj, not git.** `jj describe -m "..."` then `jj new`. Never `git`. Never backticks or `$(...)` inside a double-quoted `-m` message.
+
+## File Structure
+
+| File | Responsibility after this plan |
+|---|---|
+| `crates/tt-cli/src/commands/classify_auto/session_detail.rs` (modify) | Serves `SessionDetail` reads from a bounded pool of connections instead of one behind a mutex. Public surface (`session_tools`, `DbSessionDetail::open`, `from_database`) unchanged. |
+
+Nothing else changes. `SessionTools`, the `SessionDetail` trait in `tt-llm`, and every caller stay as they are.
+
+---
+
+### Task 1: Measure the contention before building anything
+
+**Files:**
+- Test: `crates/tt-cli/src/commands/classify_auto/session_detail/tests.rs`
+
+**Interfaces:**
+- Produces: a number, and a decision.
+
+- [ ] **Step 1: Write a test that measures lock serialization directly**
+
+```rust
+    #[test]
+    fn concurrent_fetches_report_their_serialization() {
+        use std::sync::Arc;
+        use std::time::Instant;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("tt.db");
+        {
+            let db = tt_db::Database::open(&path).unwrap();
+            // One session with enough messages that a fetch is not trivially empty.
+            insert_session_with_messages(&db, "session-1", 200);
+        }
+        let detail = Arc::new(DbSessionDetail::open(&path).unwrap());
+
+        // Serial baseline.
+        let started = Instant::now();
+        for _ in 0..64 {
+            detail.overview("session-1").unwrap();
+        }
+        let serial = started.elapsed();
+
+        // Eight workers, eight fetches each: the shape a classification chunk produces.
+        let started = Instant::now();
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let detail = Arc::clone(&detail);
+                scope.spawn(move || {
+                    for _ in 0..8 {
+                        detail.overview("session-1").unwrap();
+                    }
+                });
+            }
+        });
+        let concurrent = started.elapsed();
+
+        println!("SERIAL   64 fetches: {serial:?}");
+        println!("CONCURRENT 8x8      : {concurrent:?}");
+        println!("ratio (1.0 = fully serialized): {:.2}", concurrent.as_secs_f64() / serial.as_secs_f64());
+    }
+```
+
+Write `insert_session_with_messages` using the fixture helpers already in that test module; if none exists for agent sessions, use `tt_db::Database::upsert_agent_session` with a `user_prompts` vector of the requested length. Read the existing tests in that file and match their helpers rather than inventing new ones.
+
+- [ ] **Step 2: Run it and record the numbers**
+
+Run: `cargo test -p tt-cli --lib concurrent_fetches_report_their_serialization -- --nocapture`
+Expected: three printed lines. Record all three.
+
+- [ ] **Step 3: Measure the real thing — how much of a live pass is spent fetching**
+
+```bash
+cd /home/sami/Code/time-tracker/default
+DB=~/.local/share/time-tracker/tt.db
+# How many classifications actually fetch at all? A fetch is optional; a payload that
+# already names the work spends nothing.
+journalctl --user -u tt-serve.service --since "2 hours ago" --no-pager -o cat \
+  | sed 's/\x1b\[[0-9;]*m//g' | grep -oE "Auto-classify: .*" | tail -5
+```
+
+There is no direct fetch counter today. If one is needed to answer this, add a `fetches` field to `AutoClassifyOutcome` and its summary line **as its own commit** before continuing — an unmeasurable question is not a reason to guess.
+
+- [ ] **Step 4: DECIDE — and stop here if the answer is no**
+
+Continue to Task 2 **only if** the concurrent/serial ratio from Step 2 is meaningfully above ~1.0 (workers genuinely queueing) **and** fetches are frequent enough in a real pass to matter against a 15–90s model call.
+
+If the ratio is near 1.0 but total fetch time is microseconds against minutes of model latency, **stop, and record why**: add a short entry to `crates/tt-cli/src/commands/classify_auto/session_detail.rs`'s module doc naming the measured numbers and stating that the single mutex is deliberate because fetch time is negligible beside the model call. Then commit that and close the plan. A measured "no" is a successful outcome of this plan.
+
+```bash
+jj describe -m "docs(session-detail): record why one read connection is enough
+
+Measured: <RATIO> concurrent/serial over 64 fetches, and fetch time is
+<FIGURE> against a 15-90s model call. A read pool would be complexity for
+a rounding error."
+jj new
+```
+
+---
+
+### Task 2: Replace the single mutex with a bounded connection pool
+
+Only reachable if Task 1 Step 4 said yes.
+
+**Files:**
+- Modify: `crates/tt-cli/src/commands/classify_auto/session_detail.rs`
+- Test: `crates/tt-cli/src/commands/classify_auto/session_detail/tests.rs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 beyond its decision.
+- Produces: no public API change. `session_tools(path) -> Result<Arc<SessionTools>, tt_db::DbError>`, `DbSessionDetail::open(path)`, and `DbSessionDetail::from_database(db)` keep their exact signatures.
+
+- [ ] **Step 1: Write the failing test — concurrent fetches stop queueing**
+
+```rust
+    #[test]
+    fn a_pool_serves_concurrent_fetches_without_queueing_on_one_connection() {
+        use std::sync::Arc;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("tt.db");
+        {
+            let db = tt_db::Database::open(&path).unwrap();
+            insert_session_with_messages(&db, "session-1", 200);
+        }
+        let detail = Arc::new(DbSessionDetail::open(&path).unwrap());
+
+        // Every worker must get an answer, and none may observe a poisoned or exhausted
+        // pool. Correctness first; the timing claim is Task 1's job, not a unit test's.
+        std::thread::scope(|scope| {
+            for _ in 0..READ_POOL_SIZE * 4 {
+                let detail = Arc::clone(&detail);
+                scope.spawn(move || {
+                    let overview = detail.overview("session-1").unwrap();
+                    assert_eq!(overview.session_id, "session-1");
+                });
+            }
+        });
+
+        // And the pool is intact afterwards: a connection borrowed is a connection returned.
+        assert_eq!(detail.available_connections(), READ_POOL_SIZE);
+    }
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cargo test -p tt-cli --lib a_pool_serves_concurrent_fetches_without_queueing_on_one_connection`
+Expected: compile error — `READ_POOL_SIZE` and `available_connections` do not exist.
+
+- [ ] **Step 3: Implement the pool**
+
+Replace the `db: Mutex<Database>` field and its uses in `crates/tt-cli/src/commands/classify_auto/session_detail.rs`:
+
+```rust
+use std::sync::{Condvar, Mutex};
+
+/// Read connections the classifier may use at once.
+///
+/// Matches `CLASSIFY_CONCURRENCY` (8) so a full chunk of workers can each hold one
+/// without waiting. SQLite in WAL mode allows unlimited concurrent readers, so the only
+/// cost of a connection is a file descriptor and its page cache; the only reason to
+/// bound it at all is that an unbounded pool is a descriptor leak with extra steps.
+///
+/// This is a **read** pool. The classifier's writes stay on the single connection the
+/// resolver holds, applied serially, because `stream_named` is a non-transactional
+/// find-and-insert and two concurrent copies re-create the duplicate-stream failure that
+/// took 55 renames, 5 merges and 9 dissolves to undo.
+const READ_POOL_SIZE: usize = 8;
+
+/// Session reads for a classifier, served from a bounded pool of connections.
+pub struct DbSessionDetail {
+    idle: Mutex<Vec<Database>>,
+    returned: Condvar,
+}
+
+impl DbSessionDetail {
+    /// Opens `READ_POOL_SIZE` connections dedicated to answering the classifier's fetches.
+    ///
+    /// # Errors
+    /// When any connection cannot be opened.
+    pub fn open(path: &Path) -> Result<Self, tt_db::DbError> {
+        let mut idle = Vec::with_capacity(READ_POOL_SIZE);
+        for _ in 0..READ_POOL_SIZE {
+            idle.push(Database::open(path)?);
+        }
+        Ok(Self {
+            idle: Mutex::new(idle),
+            returned: Condvar::new(),
+        })
+    }
+
+    /// Wraps one already-open database as a pool of one.
+    ///
+    /// The in-memory test path: `Database::open_in_memory` gives each connection its own
+    /// private database, so a pool of them would not see each other's rows.
+    pub fn from_database(db: Database) -> Self {
+        Self {
+            idle: Mutex::new(vec![db]),
+            returned: Condvar::new(),
+        }
+    }
+
+    /// How many connections are currently not lent out. Test observability.
+    #[cfg(test)]
+    fn available_connections(&self) -> usize {
+        self.idle.lock().unwrap_or_else(PoisonError::into_inner).len()
+    }
+
+    /// Runs `f` against a borrowed connection, returning it to the pool afterwards.
+    ///
+    /// The connection is returned even when `f` fails, because a read that errored did
+    /// not damage the connection, and losing one per error would drain the pool.
+    fn with_connection<T>(
+        &self,
+        f: impl FnOnce(&Database) -> Result<T, SessionDetailError>,
+    ) -> Result<T, SessionDetailError> {
+        let db = {
+            let mut idle = self.idle.lock().unwrap_or_else(PoisonError::into_inner);
+            loop {
+                if let Some(db) = idle.pop() {
+                    break db;
+                }
+                idle = self
+                    .returned
+                    .wait(idle)
+                    .unwrap_or_else(PoisonError::into_inner);
+            }
+        };
+        let result = f(&db);
+        self.idle
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(db);
+        self.returned.notify_one();
+        result
+    }
+}
+```
+
+Add `use std::sync::PoisonError;`. Then rewrite each `SessionDetail` method body (`session`, `overview`, `messages`, and any others in the `impl SessionDetail for DbSessionDetail` block) to call `self.with_connection(|db| ...)` with the body that currently runs after `self.db.lock()`. **Change no query and no error mapping** — only where the connection comes from.
+
+`from_database` is deliberately a pool of one and can therefore no longer be `const fn`; drop the `const`. Check whether any caller relies on it being `const` (it is used by tests and takes an already-open `Database`), and if the compiler complains, that is the fix.
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `cargo test -p tt-cli --lib a_pool_serves_concurrent_fetches_without_queueing_on_one_connection`
+Expected: `test result: ok. 1 passed`
+
+- [ ] **Step 5: Re-run the Task 1 measurement to prove the pool changed it**
+
+Run: `cargo test -p tt-cli --lib concurrent_fetches_report_their_serialization -- --nocapture`
+Expected: the concurrent/serial ratio from Task 1 Step 2 has dropped. Record before and after. **If it did not drop, the pool is not doing anything — revert rather than ship it.**
+
+- [ ] **Step 6: Full gates**
+
+Run: `cargo fmt && cargo clippy --all-targets && cargo test`
+Expected: fmt silent, zero clippy warnings, all tests pass. The existing `session_detail/tests.rs` suite must pass unmodified — `from_database` changing from one connection to a pool of one must be invisible to it.
+
+- [ ] **Step 7: Verify the daemon and the numbers**
+
+```bash
+cp ~/.local/share/time-tracker/tt.db /tmp/pool.db
+cargo build --release --bin tt --bin tt-serve
+TT_DATABASE_PATH=/tmp/pool.db ./target/release/tt report --start 2026-07-20 --end 2026-07-21 | grep '^Direct time:'
+TT_DATABASE_PATH=/tmp/pool.db ./target/release/tt report --start 2026-07-13 --end 2026-07-20 | grep '^Direct time:'
+systemctl --user stop tt-serve.service && sleep 3
+cp target/release/tt-serve ~/.local/bin/tt-serve
+systemctl --user start tt-serve.service && sleep 60
+systemctl --user is-active tt-serve.service
+systemctl --user show tt-serve.service -p NRestarts --value
+journalctl --user -u tt-serve.service --since "2 min ago" --no-pager -o cat | grep -ci "ingest failed"
+ls -l /proc/$(systemctl --user show tt-serve.service -p MainPID --value)/fd | grep -c "tt.db"
+```
+
+Expected: `16h 23m`, `74h 20m`, `active`, `0` restarts, `0` ingest failures. The descriptor count rises by roughly `READ_POOL_SIZE` — confirm it is bounded and does not climb over the following minutes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+jj describe -m "perf(session-detail): serve classifier reads from a connection pool
+
+Every worker in a concurrent chunk took one Mutex<Database> to fetch
+session detail, so fetches were serial across the whole chunk while WAL
+allows unlimited concurrent readers. Bounded pool of READ_POOL_SIZE
+connections, borrowed and returned. Writes are untouched and stay serial
+on the resolver's single connection."
+jj new
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** The critique was that `Mutex<Database>` serializes all workers' session fetches while WAL supports concurrent readers. Task 1 measures it, Task 2 fixes it, and Task 1 Step 4 is an explicit exit if the measurement says it does not matter.
+
+**Placeholders.** Two `<RATIO>`/`<FIGURE>` markers in Task 1 Step 4's commit message, which cannot exist before Step 2 runs; the step says to fill them. One instruction to match existing fixture helpers rather than invent them, naming the file to read.
+
+**Type consistency.** `READ_POOL_SIZE` and `available_connections` are introduced in Task 2 Step 3 and used in Task 2 Step 1's test. `with_connection` takes `impl FnOnce(&Database) -> Result<T, SessionDetailError>` and every rewritten method body returns that type. `from_database` keeps its signature but loses `const`, which Step 3 calls out.
+
+**Risk flagged.** The `Condvar` wait loop is the only subtle part: it must re-check the pool after waking, which the `loop`/`pop`/`wait` shape does. A `if let ... else wait` would be a spurious-wakeup bug. Poisoning is handled by recovering the inner value rather than panicking, because a panicking reader does not corrupt a connection.

--- a/specs/implementation/2026-08-09-rearchitecture-index.md
+++ b/specs/implementation/2026-08-09-rearchitecture-index.md
@@ -1,0 +1,45 @@
+# Rearchitecture: Index and Sequencing
+
+**Scope:** The whole rearchitecture discussed on 2026-08-09 — allocation, the classifier's async shape, and the classifier's read path. Three documents because the skill requires each plan to produce working, testable software on its own, **not** because any part is deferred. All three are written; execute all three.
+
+**One sentence:** The codebase runs a Rust workload like a scripting language — everything materialized into memory, one core, and an async HTTP stack blocked into a sync trait and then re-parallelized with OS threads.
+
+## The plans
+
+| # | Plan | What it fixes | Measured payoff |
+|---|---|---|---|
+| 1 | [`2026-08-09-allocation-streaming-plan.md`](2026-08-09-allocation-streaming-plan.md) | `tt recompute` materializes 2,738,805 events **twice** and folds them on one core | **250 s → target seconds; 8.9 GB → target <1 GB; 1 core → 24** |
+| 2 | [`2026-08-09-async-classifier-plan.md`](2026-08-09-async-classifier-plan.md) | Async HTTP blocked into a sync trait, re-parallelized with OS threads, called from an async daemon | **None, and it says so.** Parity at ~7 real sessions/min. Removes a second runtime and a thread stack per call |
+| 3 | [`2026-08-09-read-pool-plan.md`](2026-08-09-read-pool-plan.md) | Every concurrent worker serializes session fetches on one `Mutex<Database>` while WAL allows unlimited readers | **Unknown — Task 1 measures it and Task 1 Step 4 is an explicit exit** |
+
+## Recommended order, and why
+
+**Plan 1 first.** It is the only one with a hard measured number (340× against the equivalent SQLite aggregate), it is entirely self-contained in the allocation path, and it touches nothing the other two touch. It also has the highest value per unit of risk: the algorithm is *already* a single forward pass, so it is a refactor rather than a rewrite.
+
+**Plan 3 second, or never.** It is small, independent, and its first task decides whether it is worth doing at all. Running it early means the answer is known before Plan 2 changes the concurrency mechanism around it. If the measurement says the contention is a rounding error against a 15–90 s model call, the correct outcome is a doc comment explaining why one connection is enough, and closing the plan.
+
+**Plan 2 last.** It is the largest, the riskiest, and — stated plainly in its own header — **buys no throughput today**. The provider rate-limits above `CLASSIFY_CONCURRENCY = 8`; 16 was measured at +18% with 2 × 429 and 6 × 529 and reverted. Plan 2 is an architecture fix, not a performance fix, and it should not displace a plan that is both.
+
+They are independent: none consumes an interface produced by another, so this order is a recommendation about risk, not a dependency graph.
+
+## Shared invariants
+
+Every plan carries these, and each states them itself:
+
+- **Direct time must not move.** `2026-07-20` prints `Direct time: 16h 23m`; `2026-07-13..2026-07-20` prints `74h 20m`. Checked before and after each task against a copy of the live database.
+- **Delegated time sums across parallel agents and routinely exceeds wall clock.** Never union, cap, or clamp it.
+- **Classifier writes stay serial on one connection.** `stream_named` is a non-transactional find-and-insert; two concurrent copies re-create the duplicate-stream failure that cost 55 renames, 5 merges and 9 dissolves. Plan 2 notes that this guarantee stops being compiler-enforced when threads become futures, which is the single thing a reviewer should check by hand.
+- Zero clippy warnings (CI is `-D warnings`), `cargo fmt` clean, `unsafe_code` denied.
+- **jj, not git.**
+
+## What is deliberately not here
+
+- **Splitting `allocation.rs` (2,490 lines) or `tt-db/src/lib.rs` (10,400 lines).** Both are far past any size ceiling and both are the house pattern. Splitting either is its own change with its own review, and doing it inside a performance refactor would make the diff unreviewable.
+- **Raising `CLASSIFY_CONCURRENCY`.** Measured and reverted; the reasoning is recorded on the constant.
+- **Anything about attribution rules.** No plan here changes what a stream is, how work is placed, or what counts as attention.
+
+## The thing worth remembering
+
+From Plan 1's `AGENTS.md` entry: **the slowness had become load-bearing.** `tt sync` was made 3.6 min → 18.6 s by *deleting* its recompute call, that deletion is now a rule with its own regression test, and `tt streams` labels its totals with their age rather than refreshing them. A 250-second function shaped three other designs before anyone treated it as a defect.
+
+That is the pattern these three plans exist to break, and it is the reason to run Plan 1 even though the product currently works: designing around a fixable 340× is how a codebase stops being able to use the language it is written in.


### PR DESCRIPTION
Three executable plans plus an index, written with the writing-plans skill.
They are three documents because each must produce working, testable software
on its own -- not because any part is deferred.

**Allocation streaming** (5 tasks) is the one with a hard number. `tt recompute`
materializes all 2,738,805 events *twice* -- once in `recompute::run` to derive
a MIN, a MAX and a warning, then again inside `allocate_for_period` -- and folds
them on one of 24 cores: **250.48s wall, 8.9 GB peak RSS, 99% CPU**, against
**0.73s and 6.4 MB** for the equivalent SQLite aggregate. It is tractable because
`allocate_time` is *already* a single forward pass; it holds the history only
because its signature takes a slice.

**Async classifier** (5 tasks) opens by stating it buys no throughput. Measured
7.1 real sessions/min at concurrency 8 with zero 429s, and 8.0/min at 16 with
2 429s and 6 529s -- the provider is the constraint, not the mechanism. It
removes a second tokio runtime and a thread stack per in-flight call.

**Read pool** (2 tasks) begins with a kill switch: Task 1 measures the lock
contention and Task 1 Step 4 is an explicit exit if it is a rounding error
against a 15-90s model call. A measured "no" is a successful outcome.

Every task carries exact file paths, interfaces, bite-sized steps with real
code, and the same acceptance gate: direct time must not move -- Jul 20 stays
16h 23m and the week of Jul 13 stays 74h 20m.
